### PR TITLE
Add support for labels to more K8sResource types

### DIFF
--- a/docs/kinds/ConfigMap.md
+++ b/docs/kinds/ConfigMap.md
@@ -7,6 +7,7 @@
 ```php
 $cm = $cluster->configmap()
     ->setName('certificates')
+    ->setLabels(['tier' => 'backend'])
     ->setData([
         'key.pem' => '...',
         'ca.pem' => '...',

--- a/docs/kinds/Ingress.md
+++ b/docs/kinds/Ingress.md
@@ -7,6 +7,7 @@
 ```php
 $ingress = $cluster->ingress()
     ->setName('nginx')
+    ->setLabels(['tier' => 'backend'])
     ->setSelectors(['app' => 'frontend'])
     ->setRules([[
         'host' => 'nginx.test.com',

--- a/docs/kinds/Resource.md
+++ b/docs/kinds/Resource.md
@@ -58,6 +58,24 @@ $namespace->getName();
 
 Alias for [setName($name)](#setnamename). It's just a naming convention for better filters on get.
 
+## Labels
+
+### `setLabels(array $labels)`
+
+Set the labels of the resource.
+
+```php
+$service->setLabels(['tier' => 'backend']);
+```
+
+### `getLabels()`
+
+Get the labels of a resource.
+
+```php
+$service->getLabels();
+```
+
 ## API
 
 ### `getApiVersion()`

--- a/docs/kinds/Service.md
+++ b/docs/kinds/Service.md
@@ -7,6 +7,7 @@
 ```php
 $svc = $cluster->service()
     ->setName('nginx')
+    ->setLabels(['tier' => 'backend'])
     ->setSelectors(['app' => 'frontend'])
     ->setPorts([
         ['protocol' => 'TCP', 'port' => 80, 'targetPort' => 80],

--- a/src/Kinds/K8sClusterRoleBinding.php
+++ b/src/Kinds/K8sClusterRoleBinding.php
@@ -2,8 +2,12 @@
 
 namespace RenokiCo\PhpK8s\Kinds;
 
+use RenokiCo\PhpK8s\Traits\HasLabels;
+
 class K8sClusterRoleBinding extends K8sRoleBinding
 {
+    use HasLabels;
+
     /**
      * The resource Kind parameter.
      *

--- a/src/Kinds/K8sConfigMap.php
+++ b/src/Kinds/K8sConfigMap.php
@@ -4,9 +4,12 @@ namespace RenokiCo\PhpK8s\Kinds;
 
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 
 class K8sConfigMap extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
+    use HasLabels;
+
     /**
      * The resource Kind parameter.
      *

--- a/src/Kinds/K8sHorizontalPodAutoscaler.php
+++ b/src/Kinds/K8sHorizontalPodAutoscaler.php
@@ -6,6 +6,7 @@ use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Scalable;
 use RenokiCo\PhpK8s\Contracts\Watchable;
 use RenokiCo\PhpK8s\Instances\ResourceMetric;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 use RenokiCo\PhpK8s\Traits\HasSpec;
 use RenokiCo\PhpK8s\Traits\HasStatus;
 use RenokiCo\PhpK8s\Traits\HasStatusConditions;
@@ -15,6 +16,7 @@ class K8sHorizontalPodAutoscaler extends K8sResource implements InteractsWithK8s
     use HasSpec;
     use HasStatus;
     use HasStatusConditions;
+    use HasLabels;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sIngress.php
+++ b/src/Kinds/K8sIngress.php
@@ -5,12 +5,14 @@ namespace RenokiCo\PhpK8s\Kinds;
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
 use RenokiCo\PhpK8s\Traits\HasAnnotations;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 use RenokiCo\PhpK8s\Traits\HasSpec;
 
 class K8sIngress extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
     use HasAnnotations;
     use HasSpec;
+    use HasLabels;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sNamespace.php
+++ b/src/Kinds/K8sNamespace.php
@@ -4,6 +4,7 @@ namespace RenokiCo\PhpK8s\Kinds;
 
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 use RenokiCo\PhpK8s\Traits\HasStatus;
 use RenokiCo\PhpK8s\Traits\HasStatusPhase;
 
@@ -11,6 +12,7 @@ class K8sNamespace extends K8sResource implements InteractsWithK8sCluster, Watch
 {
     use HasStatus;
     use HasStatusPhase;
+    use HasLabels;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sPersistentVolume.php
+++ b/src/Kinds/K8sPersistentVolume.php
@@ -5,6 +5,7 @@ namespace RenokiCo\PhpK8s\Kinds;
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
 use RenokiCo\PhpK8s\Traits\HasAccessModes;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 use RenokiCo\PhpK8s\Traits\HasMountOptions;
 use RenokiCo\PhpK8s\Traits\HasSelector;
 use RenokiCo\PhpK8s\Traits\HasSpec;
@@ -21,6 +22,7 @@ class K8sPersistentVolume extends K8sResource implements InteractsWithK8sCluster
     use HasStatus;
     use HasStatusPhase;
     use HasStorageClass;
+    use HasLabels;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sPersistentVolumeClaim.php
+++ b/src/Kinds/K8sPersistentVolumeClaim.php
@@ -5,6 +5,7 @@ namespace RenokiCo\PhpK8s\Kinds;
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
 use RenokiCo\PhpK8s\Traits\HasAccessModes;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 use RenokiCo\PhpK8s\Traits\HasSelector;
 use RenokiCo\PhpK8s\Traits\HasSpec;
 use RenokiCo\PhpK8s\Traits\HasStatus;
@@ -19,6 +20,7 @@ class K8sPersistentVolumeClaim extends K8sResource implements InteractsWithK8sCl
     use HasStatus;
     use HasStatusPhase;
     use HasStorageClass;
+    use HasLabels;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sRole.php
+++ b/src/Kinds/K8sRole.php
@@ -4,11 +4,13 @@ namespace RenokiCo\PhpK8s\Kinds;
 
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 use RenokiCo\PhpK8s\Traits\HasRules;
 
 class K8sRole extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
     use HasRules;
+    use HasLabels;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sRoleBinding.php
+++ b/src/Kinds/K8sRoleBinding.php
@@ -4,11 +4,13 @@ namespace RenokiCo\PhpK8s\Kinds;
 
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 use RenokiCo\PhpK8s\Traits\HasSubjects;
 
 class K8sRoleBinding extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
     use HasSubjects;
+    use HasLabels;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sSecret.php
+++ b/src/Kinds/K8sSecret.php
@@ -4,9 +4,12 @@ namespace RenokiCo\PhpK8s\Kinds;
 
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 
 class K8sSecret extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
+    use HasLabels;
+
     /**
      * The resource Kind parameter.
      *

--- a/src/Kinds/K8sService.php
+++ b/src/Kinds/K8sService.php
@@ -5,9 +5,9 @@ namespace RenokiCo\PhpK8s\Kinds;
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
 use RenokiCo\PhpK8s\Traits\HasAnnotations;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 use RenokiCo\PhpK8s\Traits\HasSelector;
 use RenokiCo\PhpK8s\Traits\HasSpec;
-use RenokiCo\PhpK8s\Traits\HasLabels;
 
 class K8sService extends K8sResource implements InteractsWithK8sCluster, Watchable
 {

--- a/src/Kinds/K8sService.php
+++ b/src/Kinds/K8sService.php
@@ -7,12 +7,14 @@ use RenokiCo\PhpK8s\Contracts\Watchable;
 use RenokiCo\PhpK8s\Traits\HasAnnotations;
 use RenokiCo\PhpK8s\Traits\HasSelector;
 use RenokiCo\PhpK8s\Traits\HasSpec;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 
 class K8sService extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
     use HasAnnotations;
     use HasSelector;
     use HasSpec;
+    use HasLabels;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sServiceAccount.php
+++ b/src/Kinds/K8sServiceAccount.php
@@ -4,9 +4,12 @@ namespace RenokiCo\PhpK8s\Kinds;
 
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 
 class K8sServiceAccount extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
+    use HasLabels;
+
     /**
      * The resource Kind parameter.
      *

--- a/src/Kinds/K8sStorageClass.php
+++ b/src/Kinds/K8sStorageClass.php
@@ -4,9 +4,12 @@ namespace RenokiCo\PhpK8s\Kinds;
 
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
+use RenokiCo\PhpK8s\Traits\HasLabels;
 
 class K8sStorageClass extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
+    use HasLabels;
+
     /**
      * The resource Kind parameter.
      *

--- a/tests/ClusterRoleBindingTest.php
+++ b/tests/ClusterRoleBindingTest.php
@@ -30,12 +30,14 @@ class ClusterRoleBindingTest extends TestCase
 
         $crb = $this->cluster->clusterRoleBinding()
             ->setName('user-binding')
+            ->setLabels(['tier' => 'backend'])
             ->setRole($cr)
             ->addSubjects([$subject])
             ->setSubjects([$subject]);
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $crb->getApiVersion());
         $this->assertEquals('user-binding', $crb->getName());
+        $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
     }
@@ -62,6 +64,7 @@ class ClusterRoleBindingTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $crb->getApiVersion());
         $this->assertEquals('user-binding', $crb->getName());
+        $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
     }
@@ -97,6 +100,7 @@ class ClusterRoleBindingTest extends TestCase
 
         $crb = $this->cluster->clusterRoleBinding()
             ->setName('user-binding')
+            ->setLabels(['tier' => 'backend'])
             ->setRole($cr)
             ->addSubjects([$subject])
             ->setSubjects([$subject]);
@@ -114,6 +118,7 @@ class ClusterRoleBindingTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $crb->getApiVersion());
         $this->assertEquals('user-binding', $crb->getName());
+        $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
     }
@@ -147,6 +152,7 @@ class ClusterRoleBindingTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $crb->getApiVersion());
         $this->assertEquals('user-binding', $crb->getName());
+        $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
     }
@@ -171,6 +177,7 @@ class ClusterRoleBindingTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $crb->getApiVersion());
         $this->assertEquals('user-binding', $crb->getName());
+        $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
     }

--- a/tests/ConfigMapTest.php
+++ b/tests/ConfigMapTest.php
@@ -12,12 +12,14 @@ class ConfigMapTest extends TestCase
     {
         $cm = $this->cluster->configmap()
             ->setName('settings')
+            ->setLabels(['tier' => 'backend'])
             ->setData(['somekey' => 'somevalue'])
             ->addData('key2', 'val2')
             ->removeData('somekey');
 
         $this->assertEquals('v1', $cm->getApiVersion());
         $this->assertEquals('settings', $cm->getName());
+        $this->assertEquals(['tier' => 'backend'], $cm->getLabels());
         $this->assertEquals(['key2' => 'val2'], $cm->getData());
     }
 
@@ -27,6 +29,7 @@ class ConfigMapTest extends TestCase
 
         $this->assertEquals('v1', $cm->getApiVersion());
         $this->assertEquals('settings', $cm->getName());
+        $this->assertEquals(['tier' => 'backend'], $cm->getLabels());
         $this->assertEquals(['key2' => 'val2'], $cm->getData());
     }
 
@@ -45,6 +48,7 @@ class ConfigMapTest extends TestCase
     {
         $cm = $this->cluster->configmap()
             ->setName('settings')
+            ->setLabels(['tier' => 'backend'])
             ->setData(['somekey' => 'somevalue'])
             ->addData('key2', 'val2')
             ->removeData('somekey');
@@ -61,6 +65,7 @@ class ConfigMapTest extends TestCase
 
         $this->assertEquals('v1', $cm->getApiVersion());
         $this->assertEquals('settings', $cm->getName());
+        $this->assertEquals(['tier' => 'backend'], $cm->getLabels());
         $this->assertEquals(['key2' => 'val2'], $cm->getData());
         $this->assertEquals('val2', $cm->getData('key2'));
     }
@@ -88,6 +93,7 @@ class ConfigMapTest extends TestCase
 
         $this->assertEquals('v1', $cm->getApiVersion());
         $this->assertEquals('settings', $cm->getName());
+        $this->assertEquals(['tier' => 'backend'], $cm->getLabels());
         $this->assertEquals(['key2' => 'val2'], $cm->getData());
         $this->assertEquals('val2', $cm->getData('key2'));
     }
@@ -107,6 +113,7 @@ class ConfigMapTest extends TestCase
 
         $this->assertEquals('v1', $cm->getApiVersion());
         $this->assertEquals('settings', $cm->getName());
+        $this->assertEquals(['tier' => 'backend'], $cm->getLabels());
         $this->assertEquals(['newkey' => 'newval'], $cm->getData());
         $this->assertEquals('newval', $cm->getData('newkey'));
     }

--- a/tests/HorizontalPodAutoscalerTest.php
+++ b/tests/HorizontalPodAutoscalerTest.php
@@ -35,6 +35,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $hpa = $this->cluster->horizontalPodAutoscaler()
             ->setName('mysql-hpa')
+            ->setLabels(['tier' => 'backend'])
             ->setResource($dep)
             ->addMetrics([$cpuMetric])
             ->setMetrics([$cpuMetric])
@@ -43,6 +44,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
+        $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
         $this->assertEquals(1, $hpa->getMinReplicas());
         $this->assertEquals(10, $hpa->getMaxReplicas());
@@ -74,6 +76,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
+        $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
         $this->assertEquals(1, $hpa->getMinReplicas());
         $this->assertEquals(10, $hpa->getMaxReplicas());
@@ -120,6 +123,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $hpa = $this->cluster->horizontalPodAutoscaler()
             ->setName('mysql-hpa')
+            ->setLabels(['tier' => 'backend'])
             ->setResource($dep)
             ->addMetrics([$cpuMetric])
             ->min(1)
@@ -139,6 +143,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
+        $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
         $this->assertEquals(1, $hpa->getMinReplicas());
         $this->assertEquals(10, $hpa->getMaxReplicas());
@@ -200,6 +205,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
+        $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
         $this->assertEquals(1, $hpa->getMinReplicas());
         $this->assertEquals(10, $hpa->getMaxReplicas());
@@ -227,6 +233,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
+        $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
         $this->assertEquals(1, $hpa->getMinReplicas());
         $this->assertEquals(6, $hpa->getMaxReplicas());

--- a/tests/IngressTest.php
+++ b/tests/IngressTest.php
@@ -40,12 +40,14 @@ class IngressTest extends TestCase
     {
         $ing = $this->cluster->ingress()
             ->setName('nginx')
+            ->setLabels(['tier' => 'backend'])
             ->setAnnotations(['nginx/ann' => 'yes'])
             ->addRules(self::$rules)
             ->setRules(self::$rules);
 
         $this->assertEquals('networking.k8s.io/v1beta1', $ing->getApiVersion());
         $this->assertEquals('nginx', $ing->getName());
+        $this->assertEquals(['tier' => 'backend'], $ing->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $ing->getAnnotations());
         $this->assertEquals(self::$rules, $ing->getRules());
     }
@@ -60,6 +62,7 @@ class IngressTest extends TestCase
 
         $this->assertEquals('networking.k8s.io/v1beta1', $ing->getApiVersion());
         $this->assertEquals('nginx', $ing->getName());
+        $this->assertEquals(['tier' => 'backend'], $ing->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $ing->getAnnotations());
         $this->assertEquals(self::$rules, $ing->getRules());
     }
@@ -74,6 +77,7 @@ class IngressTest extends TestCase
 
         $this->assertEquals('networking.k8s.io/v1beta1', $ing->getApiVersion());
         $this->assertEquals('nginx', $ing->getName());
+        $this->assertEquals(['tier' => 'backend'], $ing->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $ing->getAnnotations());
         $this->assertEquals(self::$rules, $ing->getRules());
     }
@@ -93,6 +97,7 @@ class IngressTest extends TestCase
     {
         $ing = $this->cluster->ingress()
             ->setName('nginx')
+            ->setLabels(['tier' => 'backend'])
             ->setAnnotations(['nginx/ann' => 'yes'])
             ->setRules(self::$rules);
 
@@ -108,6 +113,7 @@ class IngressTest extends TestCase
 
         $this->assertEquals('networking.k8s.io/v1beta1', $ing->getApiVersion());
         $this->assertEquals('nginx', $ing->getName());
+        $this->assertEquals(['tier' => 'backend'], $ing->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $ing->getAnnotations());
         $this->assertEquals(self::$rules, $ing->getRules());
     }
@@ -135,6 +141,7 @@ class IngressTest extends TestCase
 
         $this->assertEquals('networking.k8s.io/v1beta1', $ing->getApiVersion());
         $this->assertEquals('nginx', $ing->getName());
+        $this->assertEquals(['tier' => 'backend'], $ing->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $ing->getAnnotations());
         $this->assertEquals(self::$rules, $ing->getRules());
     }
@@ -153,6 +160,7 @@ class IngressTest extends TestCase
 
         $this->assertEquals('networking.k8s.io/v1beta1', $ing->getApiVersion());
         $this->assertEquals('nginx', $ing->getName());
+        $this->assertEquals(['tier' => 'backend'], $ing->getLabels());
         $this->assertEquals([], $ing->getAnnotations());
         $this->assertEquals(self::$rules, $ing->getRules());
     }

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -11,10 +11,12 @@ class NamespaceTest extends TestCase
     public function test_namespace_build()
     {
         $ns = $this->cluster->namespace()
-            ->setName('production');
+            ->setName('production')
+            ->setLabels(['tier' => 'backend']);
 
         $this->assertEquals('v1', $ns->getApiVersion());
         $this->assertEquals('production', $ns->getName());
+        $this->assertEquals(['tier' => 'backend'], $ns->getLabels());
     }
 
     public function test_namespace_from_yaml()
@@ -23,6 +25,7 @@ class NamespaceTest extends TestCase
 
         $this->assertEquals('v1', $ns->getApiVersion());
         $this->assertEquals('production', $ns->getName());
+        $this->assertEquals(['tier' => 'backend'], $ns->getLabels());
     }
 
     public function test_namespace_api_interaction()
@@ -58,12 +61,14 @@ class NamespaceTest extends TestCase
         $this->assertTrue($ns->isSynced());
 
         $this->assertEquals('production', $ns->getName());
+        $this->assertEquals(['tier' => 'backend'], $ns->getLabels());
     }
 
     public function runCreationTests()
     {
         $ns = $this->cluster->namespace()
-            ->setName('production');
+            ->setName('production')
+            ->setLabels(['tier' => 'backend']);
 
         $this->assertFalse($ns->isSynced());
         $this->assertFalse($ns->exists());
@@ -76,6 +81,7 @@ class NamespaceTest extends TestCase
         $this->assertInstanceOf(K8sNamespace::class, $ns);
 
         $this->assertEquals('production', $ns->getName());
+        $this->assertEquals(['tier' => 'backend'], $ns->getLabels());
 
         $ns->refresh();
 

--- a/tests/PersistentVolumeClaimTest.php
+++ b/tests/PersistentVolumeClaimTest.php
@@ -14,12 +14,14 @@ class PersistentVolumeClaimTest extends TestCase
 
         $pvc = $this->cluster->persistentVolumeClaim()
             ->setName('app-pvc')
+            ->setLabels(['tier' => 'backend'])
             ->setCapacity(1, 'Gi')
             ->setAccessModes(['ReadWriteOnce'])
             ->setStorageClass($standard);
 
         $this->assertEquals('v1', $pvc->getApiVersion());
         $this->assertEquals('app-pvc', $pvc->getName());
+        $this->assertEquals(['tier' => 'backend'], $pvc->getLabels());
         $this->assertEquals('1Gi', $pvc->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pvc->getAccessModes());
         $this->assertEquals('standard', $pvc->getStorageClass());
@@ -31,6 +33,7 @@ class PersistentVolumeClaimTest extends TestCase
 
         $this->assertEquals('v1', $pvc->getApiVersion());
         $this->assertEquals('app-pvc', $pvc->getName());
+        $this->assertEquals(['tier' => 'backend'], $pvc->getLabels());
         $this->assertEquals('1Gi', $pvc->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pvc->getAccessModes());
         $this->assertEquals('standard', $pvc->getStorageClass());
@@ -53,6 +56,7 @@ class PersistentVolumeClaimTest extends TestCase
 
         $pvc = $this->cluster->persistentVolumeClaim()
             ->setName('app-pvc')
+            ->setLabels(['tier' => 'backend'])
             ->setCapacity(1, 'Gi')
             ->setAccessModes(['ReadWriteOnce'])
             ->setStorageClass($standard);
@@ -69,6 +73,7 @@ class PersistentVolumeClaimTest extends TestCase
 
         $this->assertEquals('v1', $pvc->getApiVersion());
         $this->assertEquals('app-pvc', $pvc->getName());
+        $this->assertEquals(['tier' => 'backend'], $pvc->getLabels());
         $this->assertEquals('1Gi', $pvc->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pvc->getAccessModes());
         $this->assertEquals('standard', $pvc->getStorageClass());
@@ -106,6 +111,7 @@ class PersistentVolumeClaimTest extends TestCase
 
         $this->assertEquals('v1', $pvc->getApiVersion());
         $this->assertEquals('app-pvc', $pvc->getName());
+        $this->assertEquals(['tier' => 'backend'], $pvc->getLabels());
         $this->assertEquals('1Gi', $pvc->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pvc->getAccessModes());
         $this->assertEquals('standard', $pvc->getStorageClass());
@@ -123,6 +129,7 @@ class PersistentVolumeClaimTest extends TestCase
 
         $this->assertEquals('v1', $pvc->getApiVersion());
         $this->assertEquals('app-pvc', $pvc->getName());
+        $this->assertEquals(['tier' => 'backend'], $pvc->getLabels());
         $this->assertEquals('1Gi', $pvc->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pvc->getAccessModes());
         $this->assertEquals('standard', $pvc->getStorageClass());

--- a/tests/PersistentVolumeTest.php
+++ b/tests/PersistentVolumeTest.php
@@ -18,6 +18,7 @@ class PersistentVolumeTest extends TestCase
 
         $pv = $this->cluster->persistentVolume()
             ->setName('app')
+            ->setLabels(['tier' => 'backend'])
             ->setSource('awsElasticBlockStore', ['fsType' => 'ext4', 'volumeID' => 'vol-xxxxx'])
             ->setCapacity(1, 'Gi')
             ->setAccessModes(['ReadWriteOnce'])
@@ -26,6 +27,7 @@ class PersistentVolumeTest extends TestCase
 
         $this->assertEquals('v1', $pv->getApiVersion());
         $this->assertEquals('app', $pv->getName());
+        $this->assertEquals(['tier' => 'backend'], $pv->getLabels());
         $this->assertEquals(['fsType' => 'ext4', 'volumeID' => 'vol-xxxxx'], $pv->getSpec('awsElasticBlockStore'));
         $this->assertEquals('1Gi', $pv->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pv->getAccessModes());
@@ -39,6 +41,7 @@ class PersistentVolumeTest extends TestCase
 
         $this->assertEquals('v1', $pv->getApiVersion());
         $this->assertEquals('app', $pv->getName());
+        $this->assertEquals(['tier' => 'backend'], $pv->getLabels());
         $this->assertEquals(['fsType' => 'ext4', 'volumeID' => 'vol-xxxxx'], $pv->getSpec('awsElasticBlockStore'));
         $this->assertEquals('1Gi', $pv->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pv->getAccessModes());
@@ -67,6 +70,7 @@ class PersistentVolumeTest extends TestCase
 
         $pv = $this->cluster->persistentVolume()
             ->setName('app')
+            ->setLabels(['tier' => 'backend'])
             ->setSource('awsElasticBlockStore', ['fsType' => 'ext4', 'volumeID' => 'vol-xxxxx'])
             ->setCapacity(1, 'Gi')
             ->setAccessModes(['ReadWriteOnce'])
@@ -85,6 +89,7 @@ class PersistentVolumeTest extends TestCase
 
         $this->assertEquals('v1', $pv->getApiVersion());
         $this->assertEquals('app', $pv->getName());
+        $this->assertEquals(['tier' => 'backend'], $pv->getLabels());
         $this->assertEquals(['fsType' => 'ext4', 'volumeID' => 'vol-xxxxx'], $pv->getSpec('awsElasticBlockStore'));
         $this->assertEquals('1Gi', $pv->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pv->getAccessModes());
@@ -124,6 +129,7 @@ class PersistentVolumeTest extends TestCase
 
         $this->assertEquals('v1', $pv->getApiVersion());
         $this->assertEquals('app', $pv->getName());
+        $this->assertEquals(['tier' => 'backend'], $pv->getLabels());
         $this->assertEquals(['fsType' => 'ext4', 'volumeID' => 'vol-xxxxx'], $pv->getSpec('awsElasticBlockStore'));
         $this->assertEquals('1Gi', $pv->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pv->getAccessModes());
@@ -145,6 +151,7 @@ class PersistentVolumeTest extends TestCase
 
         $this->assertEquals('v1', $pv->getApiVersion());
         $this->assertEquals('app', $pv->getName());
+        $this->assertEquals(['tier' => 'backend'], $pv->getLabels());
         $this->assertEquals(['fsType' => 'ext4', 'volumeID' => 'vol-xxxxx'], $pv->getSpec('awsElasticBlockStore'));
         $this->assertEquals('1Gi', $pv->getCapacity());
         $this->assertEquals(['ReadWriteOnce'], $pv->getAccessModes());

--- a/tests/RoleBindingTest.php
+++ b/tests/RoleBindingTest.php
@@ -29,12 +29,14 @@ class RoleBindingTest extends TestCase
 
         $rb = $this->cluster->roleBinding()
             ->setName('user-binding')
+            ->setLabels(['tier' => 'backend'])
             ->setRole($role)
             ->addSubjects([$subject])
             ->setSubjects([$subject]);
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $rb->getApiVersion());
         $this->assertEquals('user-binding', $rb->getName());
+        $this->assertEquals(['tier' => 'backend'], $rb->getLabels());
         $this->assertEquals([$subject], $rb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'Role', 'name' => 'admin'], $rb->getRole());
     }
@@ -60,6 +62,7 @@ class RoleBindingTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $rb->getApiVersion());
         $this->assertEquals('user-binding', $rb->getName());
+        $this->assertEquals(['tier' => 'backend'], $rb->getLabels());
         $this->assertEquals([$subject], $rb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'Role', 'name' => 'admin'], $rb->getRole());
     }
@@ -94,6 +97,7 @@ class RoleBindingTest extends TestCase
 
         $rb = $this->cluster->roleBinding()
             ->setName('user-binding')
+            ->setLabels(['tier' => 'backend'])
             ->setRole($role)
             ->addSubjects([$subject])
             ->setSubjects([$subject]);
@@ -111,6 +115,7 @@ class RoleBindingTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $rb->getApiVersion());
         $this->assertEquals('user-binding', $rb->getName());
+        $this->assertEquals(['tier' => 'backend'], $rb->getLabels());
         $this->assertEquals([$subject], $rb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'Role', 'name' => 'admin'], $rb->getRole());
     }
@@ -144,6 +149,7 @@ class RoleBindingTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $rb->getApiVersion());
         $this->assertEquals('user-binding', $rb->getName());
+        $this->assertEquals(['tier' => 'backend'], $rb->getLabels());
         $this->assertEquals([$subject], $rb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'Role', 'name' => 'admin'], $rb->getRole());
     }
@@ -168,6 +174,7 @@ class RoleBindingTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $rb->getApiVersion());
         $this->assertEquals('user-binding', $rb->getName());
+        $this->assertEquals(['tier' => 'backend'], $rb->getLabels());
         $this->assertEquals([$subject], $rb->getSubjects());
         $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'Role', 'name' => 'admin'], $rb->getRole());
     }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -20,10 +20,12 @@ class RoleTest extends TestCase
 
         $role = $this->cluster->role()
             ->setName('admin')
+            ->setLabels(['tier' => 'backend'])
             ->addRules([$rule]);
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $role->getApiVersion());
         $this->assertEquals('admin', $role->getName());
+        $this->assertEquals(['tier' => 'backend'], $role->getLabels());
         $this->assertEquals([$rule], $role->getRules());
     }
 
@@ -39,6 +41,7 @@ class RoleTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $role->getApiVersion());
         $this->assertEquals('admin', $role->getName());
+        $this->assertEquals(['tier' => 'backend'], $role->getLabels());
         $this->assertEquals([$rule], $role->getRules());
     }
 
@@ -63,6 +66,7 @@ class RoleTest extends TestCase
 
         $role = $this->cluster->role()
             ->setName('admin')
+            ->setLabels(['tier' => 'backend'])
             ->addRules([$rule]);
 
         $this->assertFalse($role->isSynced());
@@ -77,6 +81,7 @@ class RoleTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $role->getApiVersion());
         $this->assertEquals('admin', $role->getName());
+        $this->assertEquals(['tier' => 'backend'], $role->getLabels());
         $this->assertEquals([$rule], $role->getRules());
     }
 
@@ -109,6 +114,7 @@ class RoleTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $role->getApiVersion());
         $this->assertEquals('admin', $role->getName());
+        $this->assertEquals(['tier' => 'backend'], $role->getLabels());
         $this->assertEquals([$rule], $role->getRules());
     }
 
@@ -132,6 +138,7 @@ class RoleTest extends TestCase
 
         $this->assertEquals('rbac.authorization.k8s.io/v1', $role->getApiVersion());
         $this->assertEquals('admin', $role->getName());
+        $this->assertEquals(['tier' => 'backend'], $role->getLabels());
         $this->assertEquals([$rule], $role->getRules());
     }
 

--- a/tests/SecretTest.php
+++ b/tests/SecretTest.php
@@ -12,12 +12,14 @@ class SecretTest extends TestCase
     {
         $secret = $this->cluster->secret()
             ->setName('passwords')
+            ->setLabels(['tier' => 'backend'])
             ->setData(['root' => 'somevalue'])
             ->addData('postgres', 'postgres')
             ->removeData('root');
 
         $this->assertEquals('v1', $secret->getApiVersion());
         $this->assertEquals('passwords', $secret->getName());
+        $this->assertEquals(['tier' => 'backend'], $secret->getLabels());
         $this->assertEquals(['postgres' => base64_encode('postgres')], $secret->getData(false));
         $this->assertEquals(['postgres' => 'postgres'], $secret->getData(true));
     }
@@ -28,6 +30,7 @@ class SecretTest extends TestCase
 
         $this->assertEquals('v1', $secret->getApiVersion());
         $this->assertEquals('passwords', $secret->getName());
+        $this->assertEquals(['tier' => 'backend'], $secret->getLabels());
         $this->assertEquals(['postgres' => base64_encode('postgres')], $secret->getData(false));
         $this->assertEquals(['postgres' => 'postgres'], $secret->getData(true));
     }
@@ -47,6 +50,7 @@ class SecretTest extends TestCase
     {
         $secret = $this->cluster->secret()
             ->setName('passwords')
+            ->setLabels(['tier' => 'backend'])
             ->setData(['root' => 'somevalue'])
             ->addData('postgres', 'postgres')
             ->removeData('root');
@@ -63,6 +67,7 @@ class SecretTest extends TestCase
 
         $this->assertEquals('v1', $secret->getApiVersion());
         $this->assertEquals('passwords', $secret->getName());
+        $this->assertEquals(['tier' => 'backend'], $secret->getLabels());
         $this->assertEquals(['postgres' => base64_encode('postgres')], $secret->getData(false));
         $this->assertEquals(['postgres' => 'postgres'], $secret->getData(true));
     }
@@ -90,6 +95,7 @@ class SecretTest extends TestCase
 
         $this->assertEquals('v1', $secret->getApiVersion());
         $this->assertEquals('passwords', $secret->getName());
+        $this->assertEquals(['tier' => 'backend'], $secret->getLabels());
         $this->assertEquals(['postgres' => base64_encode('postgres')], $secret->getData(false));
         $this->assertEquals(['postgres' => 'postgres'], $secret->getData(true));
     }
@@ -110,6 +116,7 @@ class SecretTest extends TestCase
 
         $this->assertEquals('v1', $secret->getApiVersion());
         $this->assertEquals('passwords', $secret->getName());
+        $this->assertEquals(['tier' => 'backend'], $secret->getLabels());
         $this->assertEquals(['root' => base64_encode('secret')], $secret->getData(false));
         $this->assertEquals(['root' => 'secret'], $secret->getData(true));
     }

--- a/tests/ServiceAccountTest.php
+++ b/tests/ServiceAccountTest.php
@@ -16,12 +16,14 @@ class ServiceAccountTest extends TestCase
 
         $sa = $this->cluster->serviceAccount()
             ->setName('user1')
+            ->setLabels(['tier' => 'backend'])
             ->addSecrets([$secret])
             ->setSecrets([$secret])
             ->addPulledSecrets(['postgres']);
 
         $this->assertEquals('v1', $sa->getApiVersion());
         $this->assertEquals('user1', $sa->getName());
+        $this->assertEquals(['tier' => 'backend'], $sa->getLabels());
         $this->assertEquals([['name' => $secret->getName()]], $sa->getSecrets());
         $this->assertEquals([['name' => 'postgres']], $sa->getImagePullSecrets());
     }
@@ -30,12 +32,14 @@ class ServiceAccountTest extends TestCase
     {
         $secret = $this->cluster->secret()
             ->setName('passwords')
+            ->setLabels(['tier' => 'backend'])
             ->addData('postgres', 'postgres');
 
         $sa = $this->cluster->fromYamlFile(__DIR__.'/yaml/serviceaccount.yaml');
 
         $this->assertEquals('v1', $sa->getApiVersion());
         $this->assertEquals('user1', $sa->getName());
+        $this->assertEquals(['tier' => 'backend'], $sa->getLabels());
         $this->assertEquals([['name' => $secret->getName()]], $sa->getSecrets());
         $this->assertEquals([['name' => 'postgres']], $sa->getImagePullSecrets());
     }
@@ -59,6 +63,7 @@ class ServiceAccountTest extends TestCase
 
         $sa = $this->cluster->serviceAccount()
             ->setName('user1')
+            ->setLabels(['tier' => 'backend'])
             ->addSecrets([$secret])
             ->setSecrets([$secret])
             ->addPulledSecrets(['postgres']);
@@ -76,6 +81,7 @@ class ServiceAccountTest extends TestCase
 
         $this->assertEquals('v1', $sa->getApiVersion());
         $this->assertEquals('user1', $sa->getName());
+        $this->assertEquals(['tier' => 'backend'], $sa->getLabels());
         $this->assertEquals([['name' => $secret->getName()]], $sa->getSecrets());
         $this->assertEquals([['name' => 'postgres']], $sa->getImagePullSecrets());
     }
@@ -104,6 +110,7 @@ class ServiceAccountTest extends TestCase
 
         $this->assertEquals('v1', $sa->getApiVersion());
         $this->assertEquals('user1', $sa->getName());
+        $this->assertEquals(['tier' => 'backend'], $sa->getLabels());
         $this->assertEquals(['name' => $secret->getName()], $sa->getSecrets()[0]);
         $this->assertEquals([['name' => 'postgres']], $sa->getImagePullSecrets());
     }
@@ -123,6 +130,7 @@ class ServiceAccountTest extends TestCase
 
         $this->assertEquals('v1', $sa->getApiVersion());
         $this->assertEquals('user1', $sa->getName());
+        $this->assertEquals(['tier' => 'backend'], $sa->getLabels());
         $this->assertEquals(['name' => $secret->getName()], $sa->getSecrets()[0]);
         $this->assertEquals([['name' => 'postgres'], ['name' => 'postgres2']], $sa->getImagePullSecrets());
     }

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -12,6 +12,7 @@ class ServiceTest extends TestCase
     {
         $svc = $this->cluster->service()
             ->setName('nginx')
+            ->setLabels(['tier' => 'backend'])
             ->setAnnotations(['nginx/ann' => 'yes'])
             ->setSelectors(['app' => 'frontend'])
             ->addPorts([['protocol' => 'TCP', 'port' => 80, 'targetPort' => 80]])
@@ -19,6 +20,7 @@ class ServiceTest extends TestCase
 
         $this->assertEquals('v1', $svc->getApiVersion());
         $this->assertEquals('nginx', $svc->getName());
+        $this->assertEquals(['tier' => 'backend'], $svc->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $svc->getAnnotations());
         $this->assertEquals(['app' => 'frontend'], $svc->getSelectors());
         $this->assertEquals([['protocol' => 'TCP', 'port' => 80, 'targetPort' => 80]], $svc->getPorts());
@@ -30,6 +32,7 @@ class ServiceTest extends TestCase
 
         $this->assertEquals('v1', $svc->getApiVersion());
         $this->assertEquals('nginx', $svc->getName());
+        $this->assertEquals(['tier' => 'backend'], $svc->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $svc->getAnnotations());
         $this->assertEquals(['app' => 'frontend'], $svc->getSelectors());
         $this->assertEquals([[
@@ -52,6 +55,7 @@ class ServiceTest extends TestCase
     {
         $svc = $this->cluster->service()
             ->setName('nginx')
+            ->setLabels(['tier' => 'backend'])
             ->setAnnotations(['nginx/ann' => 'yes'])
             ->setSelectors(['app' => 'frontend'])
             ->setPorts([
@@ -70,6 +74,7 @@ class ServiceTest extends TestCase
 
         $this->assertEquals('v1', $svc->getApiVersion());
         $this->assertEquals('nginx', $svc->getName());
+        $this->assertEquals(['tier' => 'backend'], $svc->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $svc->getAnnotations());
         $this->assertEquals(['app' => 'frontend'], $svc->getSelectors());
         $this->assertEquals([[
@@ -100,6 +105,7 @@ class ServiceTest extends TestCase
 
         $this->assertEquals('v1', $svc->getApiVersion());
         $this->assertEquals('nginx', $svc->getName());
+        $this->assertEquals(['tier' => 'backend'], $svc->getLabels());
         $this->assertEquals(['nginx/ann' => 'yes'], $svc->getAnnotations());
         $this->assertEquals(['app' => 'frontend'], $svc->getSelectors());
         $this->assertEquals([[
@@ -121,6 +127,7 @@ class ServiceTest extends TestCase
 
         $this->assertEquals('v1', $svc->getApiVersion());
         $this->assertEquals('nginx', $svc->getName());
+        $this->assertEquals(['tier' => 'backend'], $svc->getLabels());
         $this->assertEquals([], $svc->getAnnotations());
         $this->assertEquals(['app' => 'frontend'], $svc->getSelectors());
         $this->assertEquals([[

--- a/tests/StorageClassTest.php
+++ b/tests/StorageClassTest.php
@@ -12,12 +12,14 @@ class StorageClassTest extends TestCase
     {
         $sc = $this->cluster->storageClass()
             ->setName('io1')
+            ->setLabels(['tier' => 'backend'])
             ->setProvisioner('csi.aws.amazon.com')
             ->setParameters(['type' => 'io1', 'iopsPerGB' => 10])
             ->setMountOptions(['debug']);
 
         $this->assertEquals('storage.k8s.io/v1', $sc->getApiVersion());
         $this->assertEquals('io1', $sc->getName());
+        $this->assertEquals(['tier' => 'backend'], $sc->getLabels());
         $this->assertEquals('csi.aws.amazon.com', $sc->getProvisioner());
         $this->assertEquals(['type' => 'io1', 'iopsPerGB' => 10], $sc->getParameters());
         $this->assertEquals(['debug'], $sc->getMountOptions());
@@ -29,6 +31,7 @@ class StorageClassTest extends TestCase
 
         $this->assertEquals('storage.k8s.io/v1', $sc->getApiVersion());
         $this->assertEquals('io1', $sc->getName());
+        $this->assertEquals(['tier' => 'backend'], $sc->getLabels());
         $this->assertEquals('csi.aws.amazon.com', $sc->getProvisioner());
         $this->assertEquals(['type' => 'io1', 'iopsPerGB' => 10], $sc->getParameters());
         $this->assertEquals(['debug'], $sc->getMountOptions());
@@ -49,6 +52,7 @@ class StorageClassTest extends TestCase
     {
         $sc = $this->cluster->storageClass()
             ->setName('io1')
+            ->setLabels(['tier' => 'backend'])
             ->setProvisioner('csi.aws.amazon.com')
             ->setParameters(['type' => 'io1', 'iopsPerGB' => '10'])
             ->setMountOptions(['debug']);
@@ -65,6 +69,7 @@ class StorageClassTest extends TestCase
 
         $this->assertEquals('storage.k8s.io/v1', $sc->getApiVersion());
         $this->assertEquals('io1', $sc->getName());
+        $this->assertEquals(['tier' => 'backend'], $sc->getLabels());
         $this->assertEquals('csi.aws.amazon.com', $sc->getProvisioner());
         $this->assertEquals(['type' => 'io1', 'iopsPerGB' => 10], $sc->getParameters());
         $this->assertEquals(['debug'], $sc->getMountOptions());
@@ -93,6 +98,7 @@ class StorageClassTest extends TestCase
 
         $this->assertEquals('storage.k8s.io/v1', $sc->getApiVersion());
         $this->assertEquals('io1', $sc->getName());
+        $this->assertEquals(['tier' => 'backend'], $sc->getLabels());
         $this->assertEquals('csi.aws.amazon.com', $sc->getProvisioner());
         $this->assertEquals(['type' => 'io1', 'iopsPerGB' => 10], $sc->getParameters());
         $this->assertEquals(['debug'], $sc->getMountOptions());
@@ -112,6 +118,7 @@ class StorageClassTest extends TestCase
 
         $this->assertEquals('storage.k8s.io/v1', $sc->getApiVersion());
         $this->assertEquals('io1', $sc->getName());
+        $this->assertEquals(['tier' => 'backend'], $sc->getLabels());
         $this->assertEquals(['debug'], $sc->getAttribute('mountOptions'));
         $this->assertEquals(['type' => 'io1', 'iopsPerGB' => '10'], $sc->getParameters());
         $this->assertEquals(['debug'], $sc->getMountOptions());

--- a/tests/yaml/clusterrolebinding.yaml
+++ b/tests/yaml/clusterrolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: user-binding
+  labels:
+    tier: backend
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/yaml/configmap.yaml
+++ b/tests/yaml/configmap.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: settings
+  labels:
+    tier: backend
 data:
   key2: val2

--- a/tests/yaml/hpa.yaml
+++ b/tests/yaml/hpa.yaml
@@ -2,6 +2,8 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: mysql-hpa
+  labels:
+    tier: backend
 spec:
   scaleTargetRef:
     kind: Deployment

--- a/tests/yaml/ingress_post_1.18.0.yaml
+++ b/tests/yaml/ingress_post_1.18.0.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: nginx
+  labels:
+    tier: backend
   annotations:
       nginx/ann: "yes"
 spec:

--- a/tests/yaml/ingress_pre_1.18.0.yaml
+++ b/tests/yaml/ingress_pre_1.18.0.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: nginx
+  labels:
+    tier: backend
   annotations:
       nginx/ann: "yes"
 spec:

--- a/tests/yaml/namespace.yaml
+++ b/tests/yaml/namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: production
+  labels:
+    tier: backend

--- a/tests/yaml/persistentvolume.yaml
+++ b/tests/yaml/persistentvolume.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: app
+  labels:
+    tier: backend
 spec:
   awsElasticBlockStore:
     fsType: ext4

--- a/tests/yaml/persistentvolumeclaim.yaml
+++ b/tests/yaml/persistentvolumeclaim.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: app-pvc
+  labels:
+    tier: backend
 spec:
   resources:
     requests:

--- a/tests/yaml/role.yaml
+++ b/tests/yaml/role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: admin
+  labels:
+    tier: backend
 rules:
   - apiGroups: [""]
     resources:

--- a/tests/yaml/rolebinding.yaml
+++ b/tests/yaml/rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: user-binding
+  labels:
+    tier: backend
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/tests/yaml/secret.yaml
+++ b/tests/yaml/secret.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: passwords
+  labels:
+    tier: backend
 data:
   postgres: cG9zdGdyZXM= # "postgres"

--- a/tests/yaml/service.yaml
+++ b/tests/yaml/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx
+  labels:
+    tier: backend
   annotations:
     nginx/ann: "yes"
 spec:

--- a/tests/yaml/serviceaccount.yaml
+++ b/tests/yaml/serviceaccount.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: user1
+  labels:
+    tier: backend
 secrets:
   - name: passwords
 imagePullSecrets:

--- a/tests/yaml/storageclass.yaml
+++ b/tests/yaml/storageclass.yaml
@@ -2,6 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io1
+  labels:
+    tier: backend
 provisioner: csi.aws.amazon.com
 parameters:
   type: io1


### PR DESCRIPTION
This PR adds support for labels to more classes which extend the `K8sResource` class.

Right now, calling `setLabels` on, for example, `K8sService` leads to the `HasAttributes`'s `__call` method being used which adds the `labels` as a top level key rather than as a child of `metadata`. To correct the behaviour of this, the `HasLabels` must be added to all classes.

**Classes to add `HasLabels`, tests and update documentation for:**
- [x] K8sClusterRoleBinding
- [x] K8sConfigMap
- [x] K8sHorizontalPodAutoscaler
- [x] K8sIngress
- [x] K8sNamespace
- [x] K8sPersistentVolume
- [x] K8sPersistentVolumeClaim
- [x] K8sRole
- [x] K8sRoleBinding
- [x] ~K8sScale~ Scale is not an Kubernetes resource and thus I will not add `HasLabels` to it.
- [x] K8sSecret
- [x] K8sService
- [x] K8sServiceAccount
- [x] K8sStorageClass

Closes https://github.com/renoki-co/php-k8s/issues/52
