### PR TITLE
Use user.token from kube config.

### DIFF
--- a/src/Traits/Cluster/LoadsFromKubeConfig.php
+++ b/src/Traits/Cluster/LoadsFromKubeConfig.php
@@ -117,6 +117,10 @@ trait LoadsFromKubeConfig
                 $this->writeTempFileForContext($context, 'client-key.pem', $userConfig['user']['client-key-data'])
             );
         }
+
+        if (isset($userConfig['user']['token'])) {
+            $this->withToken($userConfig['user']['token']);
+        }
     }
 
     /**


### PR DESCRIPTION
user.token from the kube config file is currently being ignored.