### PR TITLE
Changed the imagePullSecrets to a spec.

### DIFF
--- a/src/Kinds/K8sIngress.php
+++ b/src/Kinds/K8sIngress.php
@@ -85,7 +85,7 @@ class K8sIngress extends K8sResource implements InteractsWithK8sCluster, Watchab
     /**
      * Set the spec tls.
      *
-     * @param  array  $rules
+     * @param  array  $tlsData
      * @return $this
      */
     public function setTls(array $tlsData = [])

--- a/src/Kinds/K8sPod.php
+++ b/src/Kinds/K8sPod.php
@@ -113,7 +113,7 @@ class K8sPod extends K8sResource implements InteractsWithK8sCluster, Watchable, 
      */
     public function addPulledSecret(string $name)
     {
-        return $this->addToAttribute('imagePullSecrets', ['name' => $name]);
+        return $this->addToSpec('imagePullSecrets', ['name' => $name]);
     }
 
     /**
@@ -138,7 +138,7 @@ class K8sPod extends K8sResource implements InteractsWithK8sCluster, Watchable, 
      */
     public function getPulledSecrets(): array
     {
-        return $this->getAttribute('imagePullSecrets', []);
+        return $this->getSpec('imagePullSecrets', []);
     }
 
     /**


### PR DESCRIPTION
Changed the imagePullSecrets to a spec rather than an attribute. The attribute was not placed in the correct yaml position.

For reference:
```
apiVersion: v1
kind: Pod
metadata:
  name: private-reg
spec:
  containers:
  - name: private-reg-container
    image: <your-private-image>
  imagePullSecrets:
  - name: regcred
```
https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret

Fixes #71 