### PR TITLE
[2.x] Custom Pods label selector from controllers

### DIFF
--- a/docs/kinds/DaemonSet.md
+++ b/docs/kinds/DaemonSet.md
@@ -2,6 +2,7 @@
   - [Example](#example)
   - [Pod Template Retrieval](#pod-template-retrieval)
   - [Getting Pods](#getting-pods)
+    - [Custom Pod Labels](#custom-pod-labels)
   - [Scaling](#scaling)
   - [Daemon Set Status](#daemon-set-status)
 
@@ -55,12 +56,41 @@ $podName = $template['name'];
 
 ## Getting Pods
 
+To get the pods, the Pod template must have the `daemonset-name` label set. This way, the `labelSelector` API parameter is issued and you may retrieve the associated pods:
+
+```yaml
+metadata:
+  name: [here it goes the daemonset name]
+spec:
+  template:
+    metadata:
+      labels:
+        daemonset-name: [here it goes the daemonset name]
+```
+
 You can retrieve the pods as resources controlled by the Daemon Set by issuing `->getPods()`:
 
 ```php
 foreach ($ds->getPods() as $pod) {
     // $pod->logs()
 }
+```
+
+### Custom Pod Labels
+
+If you cannot declare the `daemonset-name` label or simply want to use something else, you may call `selectPods` from the resource:
+
+```php
+use RenokiCo\PhpK8s\Kinds\K8sDaemonSet;
+
+K8sDaemonSet::selectPods(function (K8sDaemonSet $ds) {
+    // $ds is the current DaemonSet
+
+    return [
+        'some-label' => 'some-label-value',
+        'some-other-label' => "{$ds->getName()}-custom-name",
+    ];
+});
 ```
 
 ## Scaling

--- a/docs/kinds/Deployment.md
+++ b/docs/kinds/Deployment.md
@@ -2,6 +2,7 @@
   - [Example](#example)
   - [Pod Template Retrieval](#pod-template-retrieval)
   - [Getting Pods](#getting-pods)
+    - [Custom Pod Labels](#custom-pod-labels)
   - [Scaling](#scaling)
   - [Deployment Status](#deployment-status)
 
@@ -55,12 +56,41 @@ $podName = $template['name'];
 
 ## Getting Pods
 
+To get the pods, the Pod template must have the `deployment-name` label set. This way, the `labelSelector` API parameter is issued and you may retrieve the associated pods:
+
+```yaml
+metadata:
+  name: [here it goes the deployment name]
+spec:
+  template:
+    metadata:
+      labels:
+        deployment-name: [here it goes the deployment name]
+```
+
 You can retrieve the pods as resources controlled by the Deployment by issuing `->getPods()`:
 
 ```php
 foreach ($de->getPods() as $pod) {
     // $pod->logs()
 }
+```
+
+### Custom Pod Labels
+
+If you cannot declare the `deployment-name` label or simply want to use something else, you may call `selectPods` from the resource:
+
+```php
+use RenokiCo\PhpK8s\Kinds\K8sDeployment;
+
+K8sDeployment::selectPods(function (K8sDeployment $dep) {
+    // $dep is the current Deployment
+
+    return [
+        'some-label' => 'some-label-value',
+        'some-other-label' => "{$dep->getName()}-custom-name",
+    ];
+});
 ```
 
 ## Scaling

--- a/docs/kinds/Job.md
+++ b/docs/kinds/Job.md
@@ -2,6 +2,7 @@
   - [Example](#example)
   - [Pod Template Retrieval](#pod-template-retrieval)
   - [Getting Pods](#getting-pods)
+    - [Custom Pod Labels](#custom-pod-labels)
   - [Job's Restart Policy](#jobs-restart-policy)
   - [Job Status](#job-status)
 
@@ -53,12 +54,41 @@ $podName = $template['name'];
 
 ## Getting Pods
 
+To get the pods, the Pod template must have the `job-name` label set. This way, the `labelSelector` API parameter is issued and you may retrieve the associated pods:
+
+```yaml
+metadata:
+  name: [here it goes the job name]
+spec:
+  template:
+    metadata:
+      labels:
+        job-name: [here it goes the job name]
+```
+
 You can retrieve the pods as resources controlled by the Job by issuing `->getPods()`:
 
 ```php
 foreach ($job->getPods() as $pod) {
     // $pod->logs()
 }
+```
+
+### Custom Pod Labels
+
+If you cannot declare the `job-name` label or simply want to use something else, you may call `selectPods` from the resource:
+
+```php
+use RenokiCo\PhpK8s\Kinds\K8sJob;
+
+K8sJob::selectPods(function (K8sJob $job) {
+    // $job is the current Job
+
+    return [
+        'some-label' => 'some-label-value',
+        'some-other-label' => "{$job->getName()}-custom-name",
+    ];
+});
 ```
 
 ## Job's Restart Policy

--- a/docs/kinds/StatefulSet.md
+++ b/docs/kinds/StatefulSet.md
@@ -2,6 +2,7 @@
   - [Example](#example)
   - [Pod Template Retrieval](#pod-template-retrieval)
   - [Getting Pods](#getting-pods)
+    - [Custom Pod Labels](#custom-pod-labels)
   - [Scaling](#scaling)
   - [StatefulSet Status](#statefulset-status)
 
@@ -68,12 +69,41 @@ $podName = $template['name'];
 
 ## Getting Pods
 
+To get the pods, the Pod template must have the `statefulset-name` label set. This way, the `labelSelector` API parameter is issued and you may retrieve the associated pods:
+
+```yaml
+metadata:
+  name: [here it goes the statefulset name]
+spec:
+  template:
+    metadata:
+      labels:
+        statefulset-name: [here it goes the statefulset name]
+```
+
 You can retrieve the pods as resources controlled by the Stateful Set by issuing `->getPods()`:
 
 ```php
 foreach ($sts->getPods() as $pod) {
     // $pod->logs()
 }
+```
+
+### Custom Pod Labels
+
+If you cannot declare the `statefulset-name` label or simply want to use something else, you may call `selectPods` from the resource:
+
+```php
+use RenokiCo\PhpK8s\Kinds\K8sStatefulSet;
+
+K8sStatefulSet::selectPods(function (K8sStatefulSet $sts) {
+    // $sts is the current StatefulSet
+
+    return [
+        'some-label' => 'some-label-value',
+        'some-other-label' => "{$sts->getName()}-custom-name",
+    ];
+});
 ```
 
 ## Scaling

--- a/src/Kinds/K8sDaemonSet.php
+++ b/src/Kinds/K8sDaemonSet.php
@@ -16,7 +16,9 @@ use RenokiCo\PhpK8s\Traits\HasTemplate;
 class K8sDaemonSet extends K8sResource implements InteractsWithK8sCluster, Podable, Watchable
 {
     use HasMinimumSurge;
-    use HasPods;
+    use HasPods {
+        podsSelector as protected customPodsSelector;
+    }
     use HasSelector;
     use HasSpec;
     use HasStatus;
@@ -67,6 +69,10 @@ class K8sDaemonSet extends K8sResource implements InteractsWithK8sCluster, Podab
      */
     public function podsSelector(): array
     {
+        if ($podsSelector = $this->customPodsSelector()) {
+            return $podsSelector;
+        }
+
         return [
             'daemonset-name' => $this->getName(),
         ];

--- a/src/Kinds/K8sDeployment.php
+++ b/src/Kinds/K8sDeployment.php
@@ -24,7 +24,9 @@ class K8sDeployment extends K8sResource implements
 {
     use CanScale;
     use HasMinimumSurge;
-    use HasPods;
+    use HasPods {
+        podsSelector as protected customPodsSelector;
+    }
     use HasReplicas;
     use HasSelector;
     use HasSpec;
@@ -78,6 +80,10 @@ class K8sDeployment extends K8sResource implements
      */
     public function podsSelector(): array
     {
+        if ($podsSelector = $this->customPodsSelector()) {
+            return $podsSelector;
+        }
+
         return [
             'deployment-name' => $this->getName(),
         ];

--- a/src/Kinds/K8sJob.php
+++ b/src/Kinds/K8sJob.php
@@ -18,7 +18,9 @@ class K8sJob extends K8sResource implements
     Podable,
     Watchable
 {
-    use HasPods;
+    use HasPods {
+        podsSelector as protected customPodsSelector;
+    }
     use HasSelector;
     use HasSpec;
     use HasStatus;
@@ -64,6 +66,10 @@ class K8sJob extends K8sResource implements
      */
     public function podsSelector(): array
     {
+        if ($podsSelector = $this->customPodsSelector()) {
+            return $podsSelector;
+        }
+
         return [
             'job-name' => $this->getName(),
         ];

--- a/src/Kinds/K8sStatefulSet.php
+++ b/src/Kinds/K8sStatefulSet.php
@@ -22,7 +22,9 @@ class K8sStatefulSet extends K8sResource implements
     Watchable
 {
     use CanScale;
-    use HasPods;
+    use HasPods {
+        podsSelector as protected customPodsSelector;
+    }
     use HasReplicas;
     use HasSelector;
     use HasSpec;
@@ -147,6 +149,10 @@ class K8sStatefulSet extends K8sResource implements
      */
     public function podsSelector(): array
     {
+        if ($podsSelector = $this->customPodsSelector()) {
+            return $podsSelector;
+        }
+
         return [
             'statefulset-name' => $this->getName(),
         ];

--- a/src/Traits/HasPods.php
+++ b/src/Traits/HasPods.php
@@ -11,7 +11,7 @@ trait HasPods
      *
      * @var Closure|null
      */
-    protected $podSelctorCallback;
+    protected static $podSelctorCallback;
 
     /**
      * Get the selector for the pods that are owned by this resource.

--- a/src/Traits/HasPods.php
+++ b/src/Traits/HasPods.php
@@ -2,8 +2,54 @@
 
 namespace RenokiCo\PhpK8s\Traits;
 
+use Closure;
+
 trait HasPods
 {
+    /**
+     * Custom closure to set a dynamic pod selector.
+     *
+     * @var Closure|null
+     */
+    protected $podSelctorCallback;
+
+    /**
+     * Get the selector for the pods that are owned by this resource.
+     *
+     * @return array
+     */
+    public function podsSelector(): array
+    {
+        if ($callback = static::$podSelctorCallback) {
+            return $callback($this);
+        }
+
+        return [
+            //
+        ];
+    }
+
+    /**
+     * Reset the pods selector callback.
+     *
+     * @return void
+     */
+    public static function resetPodsSelector(): void
+    {
+        static::$podSelctorCallback = null;
+    }
+
+    /**
+     * Dynamically select the pods based on selectors.
+     *
+     * @param  Closure  $callback
+     * @return void
+     */
+    public static function selectPods(Closure $callback): void
+    {
+        static::$podSelctorCallback = $callback;
+    }
+
     /**
      * Get the pods owned by this resource.
      *

--- a/tests/DaemonSetTest.php
+++ b/tests/DaemonSetTest.php
@@ -120,8 +120,18 @@ class DaemonSetTest extends TestCase
             sleep(1);
         }
 
-        $pods = $ds->getPods();
+        K8sDaemonSet::selectPods(function ($ds) {
+            $this->assertInstanceOf(K8sDaemonSet::class, $ds);
 
+            return ['tier' => 'backend'];
+        });
+
+        $pods = $ds->getPods();
+        $this->assertTrue($pods->count() > 0);
+
+        K8sDaemonSet::resetPodsSelector();
+
+        $pods = $ds->getPods();
         $this->assertTrue($pods->count() > 0);
 
         foreach ($pods as $pod) {

--- a/tests/DeploymentTest.php
+++ b/tests/DeploymentTest.php
@@ -130,8 +130,18 @@ class DeploymentTest extends TestCase
             sleep(1);
         }
 
-        $pods = $dep->getPods();
+        K8sDeployment::selectPods(function ($dep) {
+            $this->assertInstanceOf(K8sDeployment::class, $dep);
 
+            return ['tier' => 'backend'];
+        });
+
+        $pods = $dep->getPods();
+        $this->assertTrue($pods->count() > 0);
+
+        K8sDeployment::resetPodsSelector();
+
+        $pods = $dep->getPods();
         $this->assertTrue($pods->count() > 0);
 
         foreach ($pods as $pod) {

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -121,8 +121,18 @@ class JobTest extends TestCase
             $job->refresh();
         }
 
-        $pods = $job->getPods();
+        K8sJob::selectPods(function ($job) {
+            $this->assertInstanceOf(K8sJob::class, $job);
 
+            return ['tier' => 'backend'];
+        });
+
+        $pods = $job->getPods();
+        $this->assertTrue($pods->count() > 0);
+
+        K8sJob::resetPodsSelector();
+
+        $pods = $job->getPods();
         $this->assertTrue($pods->count() > 0);
 
         foreach ($pods as $pod) {

--- a/tests/StatefulSetTest.php
+++ b/tests/StatefulSetTest.php
@@ -185,8 +185,18 @@ class StatefulSetTest extends TestCase
             sleep(1);
         }
 
-        $pods = $sts->getPods();
+        K8sStatefulSet::selectPods(function ($sts) {
+            $this->assertInstanceOf(K8sStatefulSet::class, $sts);
 
+            return ['tier' => 'backend'];
+        });
+
+        $pods = $sts->getPods();
+        $this->assertTrue($pods->count() > 0);
+
+        K8sStatefulSet::resetPodsSelector();
+
+        $pods = $sts->getPods();
         $this->assertTrue($pods->count() > 0);
 
         foreach ($pods as $pod) {


### PR DESCRIPTION
Fixes #61 

You may call the pods selector dynamically at runtime for Deployments, StatefulSets, Jobs and DaemonSets:

```php
use RenokiCo\PhpK8s\Kinds\K8sDaemonSet;

K8sDaemonSet::selectPods(function (K8sDaemonSet $ds) {
    // $ds is the current DaemonSet

    return [
        'some-label' => 'some-label-value',
        'some-other-label' => "{$ds->getName()}-custom-name",
    ];
});

// This will return pods that have matching labels with the array from above.
foreach ($ds->getPods() as $pod) {
    //
}
```