### PR TITLE
Should refresh the origin before checking changes

### DIFF
--- a/src/Traits/RunsClusterOperations.php
+++ b/src/Traits/RunsClusterOperations.php
@@ -195,12 +195,12 @@ trait RunsClusterOperations
      */
     public function update(array $query = ['pretty' => 1]): bool
     {
+        $this->refreshOriginal();
+
         // If it didn't change, no way to trigger the change.
         if (! $this->hasChanged()) {
             return true;
         }
-
-        $this->refreshOriginal();
 
         $instance = $this->cluster
             ->setResourceClass(get_class($this))


### PR DESCRIPTION
This bug causes the `createOrUpdate` don't work as expected. e.g.

```
$cluster->ingress()->setName('test-ingress')->setRules([])->createOrUpdate();
```

This works well when `test-ingress` doesn't exist, but won't execute the updating if it already exists.

This is because `$cluster->ingress()->setName('test-ingress')->setRules([])` will create a new `K8sIngress` object with `$synced = false` and `$original = []`, the `hasChanged()` method will return `false` in this case, so it won't perform the updating in result.