### PR TITLE
[2.x] Using stream content for watching resources

### DIFF
--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -417,7 +417,7 @@ class KubernetesCluster
             $streamContext = stream_context_create($streamOptions);
         }
 
-        $sock =  fopen($callableUrl, 'r', false, $streamContext);
+        $sock = fopen($callableUrl, 'r', false, $streamContext);
 
         return $sock;
     }
@@ -458,7 +458,7 @@ class KubernetesCluster
             'http' => [
                 'header' => $headers,
             ],
-            'ssl' => $sslOptions
+            'ssl' => $sslOptions,
         ];
     }
 

--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -7,7 +7,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Str;
-use phpDocumentor\Reflection\Types\Resource_;
 use Ratchet\Client\Connector as WebSocketConnector;
 use React\EventLoop\Factory as ReactFactory;
 use React\Socket\Connector as ReactSocketConnector;
@@ -428,7 +427,7 @@ class KubernetesCluster
      */
     private function makeStreamContextOptions(): array
     {
-        $sslOptions = $headers = [] ;
+        $sslOptions = $headers = [];
 
         if (is_bool($this->verify)) {
             $sslOptions['verify_peer'] = $this->verify;

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -73,7 +73,7 @@ class KubeConfigTest extends TestCase
                 'cafile' => '/path/to/.minikube/ca.crt',
                 'local_cert' => '/path/to/.minikube/client.crt',
                 'local_pk' => '/path/to/.minikube/client.key',
-            ]
+            ],
         ]);
     }
 

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -54,6 +54,30 @@ class KubeConfigTest extends TestCase
         $this->assertEquals('/path/to/.minikube/client.key', $keyPath);
     }
 
+    public function test_cluster_can_get_correct_config_for_socket_connection()
+    {
+        $cluster = new KubernetesCluster('http://127.0.0.1:8080');
+
+        $cluster->fromKubeConfigYamlFile(__DIR__.'/cluster/kubeconfig.yaml', 'minikube-2');
+
+        $reflectionMethod = new \ReflectionMethod($cluster, 'makeStreamContextOptions');
+        $reflectionMethod->setAccessible(true);
+
+        $options = $reflectionMethod->invoke($cluster);
+
+        $this->assertEquals([
+            "http" => [
+                "header" => []
+            ],
+            'ssl' => [
+                "cafile" => "/path/to/.minikube/ca.crt",
+                "local_cert" => "/path/to/.minikube/client.crt",
+                "local_pk" => "/path/to/.minikube/client.key",
+            ]
+        ]);
+    }
+
+
     public function test_kube_config_from_yaml_cannot_load_if_no_cluster()
     {
         $cluster = new KubernetesCluster('http://127.0.0.1:8080');

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -66,13 +66,13 @@ class KubeConfigTest extends TestCase
         $options = $reflectionMethod->invoke($cluster);
 
         $this->assertEquals([
-            "http" => [
-                "header" => []
+            'http' => [
+                'header' => [],
             ],
             'ssl' => [
-                "cafile" => "/path/to/.minikube/ca.crt",
-                "local_cert" => "/path/to/.minikube/client.crt",
-                "local_pk" => "/path/to/.minikube/client.key",
+                'cafile' => '/path/to/.minikube/ca.crt',
+                'local_cert' => '/path/to/.minikube/client.crt',
+                'local_pk' => ''/path/to/.minikube/client.key',
             ]
         ]);
     }

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -74,7 +74,7 @@ class KubeConfigTest extends TestCase
                 'local_cert' => '/path/to/.minikube/client.crt',
                 'local_pk' => '/path/to/.minikube/client.key',
             ],
-        ]);
+        ], $options);
     }
 
     public function test_kube_config_from_yaml_cannot_load_if_no_cluster()

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -60,7 +60,7 @@ class KubeConfigTest extends TestCase
 
         $cluster->loadTokenFromFile(__DIR__.'/cluster/token.txt');
 
-        $reflectionMethod = new \ReflectionMethod($cluster, 'makeStreamContextOptions');
+        $reflectionMethod = new \ReflectionMethod($cluster, 'buildStreamContextOptions');
         $reflectionMethod->setAccessible(true);
 
         $options = $reflectionMethod->invoke($cluster);
@@ -82,7 +82,7 @@ class KubeConfigTest extends TestCase
 
         $cluster->httpAuthentication('some-user', 'some-password');
 
-        $reflectionMethod = new \ReflectionMethod($cluster, 'makeStreamContextOptions');
+        $reflectionMethod = new \ReflectionMethod($cluster, 'buildStreamContextOptions');
         $reflectionMethod->setAccessible(true);
 
         $options = $reflectionMethod->invoke($cluster);
@@ -104,7 +104,7 @@ class KubeConfigTest extends TestCase
 
         $cluster->fromKubeConfigYamlFile(__DIR__.'/cluster/kubeconfig.yaml', 'minikube-2');
 
-        $reflectionMethod = new \ReflectionMethod($cluster, 'makeStreamContextOptions');
+        $reflectionMethod = new \ReflectionMethod($cluster, 'buildStreamContextOptions');
         $reflectionMethod->setAccessible(true);
 
         $options = $reflectionMethod->invoke($cluster);

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -72,7 +72,7 @@ class KubeConfigTest extends TestCase
             'ssl' => [
                 'cafile' => '/path/to/.minikube/ca.crt',
                 'local_cert' => '/path/to/.minikube/client.crt',
-                'local_pk' => ''/path/to/.minikube/client.key',
+                'local_pk' => '/path/to/.minikube/client.key',
             ]
         ]);
     }

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -54,7 +54,51 @@ class KubeConfigTest extends TestCase
         $this->assertEquals('/path/to/.minikube/client.key', $keyPath);
     }
 
-    public function test_cluster_can_get_correct_config_for_socket_connection()
+    public function test_cluster_can_get_correct_config_for_token_socket_connection()
+    {
+        $cluster = new KubernetesCluster('http://127.0.0.1:8080');
+
+        $cluster->loadTokenFromFile(__DIR__.'/cluster/token.txt');
+
+        $reflectionMethod = new \ReflectionMethod($cluster, 'makeStreamContextOptions');
+        $reflectionMethod->setAccessible(true);
+
+        $options = $reflectionMethod->invoke($cluster);
+
+        $this->assertEquals([
+            'http' => [
+                'header' => [
+                    'Authorization: Bearer some-token'
+                ],
+            ],
+            'ssl' => [
+            ],
+        ], $options);
+    }
+
+    public function test_cluster_can_get_correct_config_for_user_pass_socket_connection()
+    {
+        $cluster = new KubernetesCluster('http://127.0.0.1:8080');
+
+        $cluster->httpAuthentication('some-user', 'some-password');
+
+        $reflectionMethod = new \ReflectionMethod($cluster, 'makeStreamContextOptions');
+        $reflectionMethod->setAccessible(true);
+
+        $options = $reflectionMethod->invoke($cluster);
+
+        $this->assertEquals([
+            'http' => [
+                'header' => [
+                    'Authorization: Basic c29tZS11c2VyOnNvbWUtcGFzc3dvcmQ='
+                ],
+            ],
+            'ssl' => [
+            ],
+        ], $options);
+    }
+
+    public function test_cluster_can_get_correct_config_for_ssl_socket_connection()
     {
         $cluster = new KubernetesCluster('http://127.0.0.1:8080');
 

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -77,7 +77,6 @@ class KubeConfigTest extends TestCase
         ]);
     }
 
-
     public function test_kube_config_from_yaml_cannot_load_if_no_cluster()
     {
         $cluster = new KubernetesCluster('http://127.0.0.1:8080');

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -68,7 +68,7 @@ class KubeConfigTest extends TestCase
         $this->assertEquals([
             'http' => [
                 'header' => [
-                    'Authorization: Bearer some-token'
+                    'Authorization: Bearer some-token',
                 ],
             ],
             'ssl' => [
@@ -90,7 +90,7 @@ class KubeConfigTest extends TestCase
         $this->assertEquals([
             'http' => [
                 'header' => [
-                    'Authorization: Basic c29tZS11c2VyOnNvbWUtcGFzc3dvcmQ='
+                    'Authorization: Basic c29tZS11c2VyOnNvbWUtcGFzc3dvcmQ=',
                 ],
             ],
             'ssl' => [


### PR DESCRIPTION
when trying to use the watch method on created resources on my minikube instance I ran into 403 errors being not authenticated. On inspecting the source it seemed clear that adding authentication was missing to the fopen methods. This PR adds a stream_context_create resource to the fopen calls if neccesary 