### PR TITLE
[3.x] Template YAML file to resource

### DIFF
--- a/src/K8s.php
+++ b/src/K8s.php
@@ -60,6 +60,28 @@ class K8s
     }
 
     /**
+     * Load Kind configuration fron a YAML file, making sure to
+     * replace all variables in curly braces with the values from
+     * the given array.
+     *
+     * @param  \RenokiCo\PhpK8s\Kinds\KubernetesCluster|null  $cluster
+     * @param  string  $path
+     * @param  array  $replace
+     * @param  \Closure|null  $callback
+     * @return \RenokiCo\PhpK8s\Kinds\K8sResource|array[\RenokiCo\PhpK8s\Kinds\K8sResource]
+     */
+    public static function fromTemplatedYamlFile($cluster, string $path, array $replace, Closure $callback = null)
+    {
+        return static::fromYamlFile($cluster, $path, function ($content) use ($replace, $callback) {
+            foreach ($replace as $search => $replacement) {
+                $content = str_replace("{{$search}}", $replacement, $content);
+            }
+
+            return $callback ? $callback($content) : $content;
+        });
+    }
+
+    /**
      * Proxy the K8s call to cluster object.
      *
      * @param  string  $method

--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -98,6 +98,9 @@ use RenokiCo\PhpK8s\Kinds\K8sResource;
  * @method \RenokiCo\PhpK8s\Kinds\K8sPodDisruptionBudget getPodDisruptionBudgetByName(string $name, string $namespace = 'default', array $query = ['pretty' => 1])
  * @method \RenokiCo\PhpK8s\ResourcesList getAllPodDisruptionBudgetsFromAllNamespaces(array $query = ['pretty' => 1])
  * @method \RenokiCo\PhpK8s\ResourcesList getAllPodDisruptionBudgets(string $namespace = 'default', array $query = ['pretty' => 1])
+ * @method \RenokiCo\PhpK8s\Kinds\K8sResource|array[\RenokiCo\PhpK8s\Kinds\K8sResource] fromYaml(string $yaml)
+ * @method \RenokiCo\PhpK8s\Kinds\K8sResource|array[\RenokiCo\PhpK8s\Kinds\K8sResource] fromYamlFile(string $path, \Closure $callback = null)
+ * @method \RenokiCo\PhpK8s\Kinds\K8sResource|array[\RenokiCo\PhpK8s\Kinds\K8sResource] fromTemplatedYamlFile(string $path, array $replace, \Closure $callback = null)
  *
  * @see \RenokiCo\PhpK8s\K8s
  */

--- a/tests/YamlTest.php
+++ b/tests/YamlTest.php
@@ -30,4 +30,18 @@ class YamlTest extends TestCase
         $this->assertEquals('settings', $cm->getName());
         $this->assertEquals(['key' => 'assigned_value'], $cm->getData());
     }
+
+    public function test_yaml_template()
+    {
+        $replacements = [
+            'value' => 'assigned_value_at_template',
+            'value2' => 'not_assigned',
+        ];
+
+        $cm = $this->cluster->fromTemplatedYamlFile(__DIR__.'/yaml/configmap_with_placeholder.yaml', $replacements);
+
+        $this->assertEquals('v1', $cm->getApiVersion());
+        $this->assertEquals('settings', $cm->getName());
+        $this->assertEquals(['key' => 'assigned_value_at_template'], $cm->getData());
+    }
 }


### PR DESCRIPTION
Given this yaml file:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: settings
data:
  key1: "{value1}"
  key2: "{value2}"
```

It can import the configmap with the injected values:

```php
$cm = $cluster->fromTemplatedYamlFile('file.yaml', [
    'value1' => 'some-value-for-key-1',
    'value2' => 'some-value-for-key-2',
]);
```

PHP K8s will replace all `{variables}` between brackets with the values from the given array and import the YAML.