### PR TITLE
[feature] CRD register

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php:
           - '7.4'

--- a/src/K8s.php
+++ b/src/K8s.php
@@ -3,6 +3,7 @@
 namespace RenokiCo\PhpK8s;
 
 use Closure;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use RenokiCo\PhpK8s\Traits\InitializesInstances;
 use RenokiCo\PhpK8s\Traits\InitializesResources;
@@ -91,7 +92,7 @@ class K8s
     public static function registerCrd(string $class, string $name = null): void
     {
         static::macro(
-            $name ?: substr($class, strrpos($class, '\\') + 1),
+            Str::camel($name ?: substr($class, strrpos($class, '\\') + 1)),
             function ($cluster = null, array $attributes = []) use ($class) {
                 return new $class($cluster, $attributes);
             }

--- a/src/K8s.php
+++ b/src/K8s.php
@@ -91,7 +91,7 @@ class K8s
     public static function registerCrd(string $class, string $name = null): void
     {
         static::macro(
-            $name ?: substr($class, strrpos($class, '\\')+  1),
+            $name ?: substr($class, strrpos($class, '\\') + 1),
             function ($cluster = null, array $attributes = []) use ($class) {
                 return new $class($cluster, $attributes);
             }

--- a/src/K8s.php
+++ b/src/K8s.php
@@ -82,6 +82,23 @@ class K8s
     }
 
     /**
+     * Register a CRD inside the package.
+     *
+     * @param  string  $class
+     * @param  string|null  $name
+     * @return void
+     */
+    public static function registerCrd(string $class, string $name = null): void
+    {
+        static::macro(
+            $name ?: substr($class, strrpos($class, '\\')+  1),
+            function ($cluster = null, array $attributes = []) use ($class) {
+                return new $class($cluster, $attributes);
+            }
+        );
+    }
+
+    /**
      * Proxy the K8s call to cluster object.
      *
      * @param  string  $method

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -40,9 +40,7 @@ class MacroTest extends TestCase
 
     public function test_k8s_macro()
     {
-        K8s::macro('newResource', function ($cluster = null, $attributes = []) {
-            return new Kinds\NewResource($cluster, $attributes);
-        });
+        K8s::registerCrd(Kinds\NewResource::class);
 
         $this->assertInstanceOf(Kinds\NewResource::class, K8s::newResource());
         $this->assertInstanceOf(Kinds\NewResource::class, (new K8s)->newResource());

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -41,9 +41,14 @@ class MacroTest extends TestCase
     public function test_k8s_macro()
     {
         K8s::registerCrd(Kinds\NewResource::class);
+        K8s::registerCrd(Kinds\NewResource::class, 'nr');
 
         $this->assertInstanceOf(Kinds\NewResource::class, K8s::newResource());
         $this->assertInstanceOf(Kinds\NewResource::class, (new K8s)->newResource());
         $this->assertInstanceOf(Kinds\NewResource::class, $this->cluster->newResource());
+
+        $this->assertInstanceOf(Kinds\NewResource::class, K8s::nr());
+        $this->assertInstanceOf(Kinds\NewResource::class, (new K8s)->nr());
+        $this->assertInstanceOf(Kinds\NewResource::class, $this->cluster->nr());
     }
 }


### PR DESCRIPTION
Ref: https://github.com/renoki-co/laravel-php-k8s/issues/12

```php
use RenokiCo\PhpK8s\K8s;

K8s::registerCrd(Kinds\GameServer::class);

foreach ($cluster->GameServer()->all() as $gs) {
    //
}
```

Optionally, you may pass a second argument to define the name to call by:

```php
use RenokiCo\PhpK8s\K8s;

K8s::registerCrd(Kinds\GameServer::class, 'gs');

foreach ($cluster->gs()->all() as $gs) {
    //
}
```