### PR TITLE
Added ability to directly load a kubeconfig from an array

### DIFF
--- a/src/Traits/Cluster/LoadsFromKubeConfig.php
+++ b/src/Traits/Cluster/LoadsFromKubeConfig.php
@@ -99,6 +99,20 @@ trait LoadsFromKubeConfig
     }
 
     /**
+     * Load configuration from an Array.
+     *
+     * @param  array  $kubeConfigArray
+     * @param  string|null  $context
+     * @return \RenokiCo\PhpK8s\KubernetesCluster
+     */
+    public static function fromKubeConfigArray(array $kubeConfigArray, string $context = null)
+    {
+        $cluster = new static;
+
+        return $cluster->loadKubeConfigFromArray($kubeConfigArray, $context);
+    }
+
+    /**
      * Load the Kube Config configuration from an array,
      * coming from a Kube Config file.
      *

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -194,4 +194,19 @@ class KubeConfigTest extends TestCase
         yield ['minikube-2', 'minikube-2'];
         yield ['minikube-3', 'minikube-3'];
     }
+
+    public function test_kube_config_from_array_with_base64_encoded_ssl()
+    {
+        $cluster = KubernetesCluster::fromKubeConfigArray(yaml_parse_file(__DIR__.'/cluster/kubeconfig.yaml'), 'minikube');
+
+        [
+            'verify' => $caPath,
+            'cert' => $certPath,
+            'ssl_key' => $keyPath,
+        ] = $cluster->getClient()->getConfig();
+
+        $this->assertEquals("some-ca\n", file_get_contents($caPath));
+        $this->assertEquals("some-cert\n", file_get_contents($certPath));
+        $this->assertEquals("some-key\n", file_get_contents($keyPath));
+    }
 }


### PR DESCRIPTION
Im working on an application that builds a kubeconfig (array) within PHP. It would be nice to directly use that as config in php-k8s. Currenly i have to convert it to a yaml, only for to be parsed back to an array in `fromKubeConfigYaml`