### PR TITLE
Check whether provided base64 encoded data in KubeConfig is valid

### DIFF
--- a/src/Exceptions/KubeConfigBaseEncodedDataInvalid.php
+++ b/src/Exceptions/KubeConfigBaseEncodedDataInvalid.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Exceptions;
+
+class KubeConfigBaseEncodedDataInvalid extends PhpK8sException
+{
+    //
+}

--- a/src/Traits/Cluster/LoadsFromKubeConfig.php
+++ b/src/Traits/Cluster/LoadsFromKubeConfig.php
@@ -4,6 +4,7 @@ namespace RenokiCo\PhpK8s\Traits\Cluster;
 
 use Exception;
 use Illuminate\Support\Arr;
+use RenokiCo\PhpK8s\Exceptions\KubeConfigBaseEncodedDataInvalid;
 use RenokiCo\PhpK8s\Exceptions\KubeConfigClusterNotFound;
 use RenokiCo\PhpK8s\Exceptions\KubeConfigContextNotFound;
 use RenokiCo\PhpK8s\Exceptions\KubeConfigUserNotFound;
@@ -219,7 +220,13 @@ trait LoadsFromKubeConfig
             return $tempFilePath;
         }
 
-        if (file_put_contents($tempFilePath, base64_decode($contents, true)) === false) {
+        $decodedContents = base64_decode($contents, true);
+
+        if ($decodedContents === false) {
+            throw new KubeConfigBaseEncodedDataInvalid("Failed to decode base64-encoded data for: {$fileName}");
+        }
+
+        if (file_put_contents($tempFilePath, $decodedContents) === false) {
             throw new Exception("Failed to write content to temp file: {$tempFilePath}");
         }
 

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -2,6 +2,7 @@
 
 namespace RenokiCo\PhpK8s\Test;
 
+use RenokiCo\PhpK8s\Exceptions\KubeConfigBaseEncodedDataInvalid;
 use RenokiCo\PhpK8s\Exceptions\KubeConfigClusterNotFound;
 use RenokiCo\PhpK8s\Exceptions\KubeConfigContextNotFound;
 use RenokiCo\PhpK8s\Exceptions\KubeConfigUserNotFound;
@@ -155,6 +156,13 @@ class KubeConfigTest extends TestCase
         $this->expectException(KubeConfigContextNotFound::class);
 
         KubernetesCluster::fromKubeConfigYamlFile(__DIR__.'/cluster/kubeconfig.yaml', 'inexistent-context');
+    }
+
+    public function test_kube_config_from_yaml_invalid_base64_ca()
+    {
+        $this->expectException(KubeConfigBaseEncodedDataInvalid::class);
+
+        KubernetesCluster::fromKubeConfigYamlFile(__DIR__.'/cluster/kubeconfig.yaml', 'minikube-invalid-base64-ca');
     }
 
     public function test_http_authentication()

--- a/tests/cluster/kubeconfig.yaml
+++ b/tests/cluster/kubeconfig.yaml
@@ -13,6 +13,10 @@ clusters:
     server: https://minikube-2:8443
     insecure-skip-tls-verify: true
   name: minikube-skip-tls
+- cluster:
+    certificate-authority-data: c29tZS1j1YQo= # invalid base64
+    server: https://minikube:8443
+  name: minikube-invalid-base64-ca
 contexts:
 - context:
     cluster: minikube
@@ -38,6 +42,11 @@ contexts:
     cluster: minikube
     user: no-user
   name: minikube-without-user
+  namespace: some-namespace
+- context:
+    cluster: minikube-invalid-base64-ca
+    user: minikube
+  name: minikube-invalid-base64-ca
   namespace: some-namespace
 current-context: minikube
 kind: Config


### PR DESCRIPTION
Hi again, thanks for the quick response on my last PR. 

I came across another minor thing, while testing i inadvertently used an invalid base64 encoded certificate in my kube config. This did not result in a clear error message, as the `file_put_contents` function successfully wrote the bool `false` as contents of the certificate.pem file. Later down the line this resulted in an less obvious Curl error 58.

Therefore i added a check to make sure it at least was able to decoding something from the base64 contents.