### PR TITLE
Fix KubeConfig temp certificate filename extension .pem

### DIFF
--- a/src/Traits/Cluster/LoadsFromKubeConfig.php
+++ b/src/Traits/Cluster/LoadsFromKubeConfig.php
@@ -244,7 +244,7 @@ trait LoadsFromKubeConfig
         /** @var \RenokiCo\PhpK8s\KubernetesCluster $this */
         $tempFolder = static::$tempFolder ?: sys_get_temp_dir();
 
-        $tempFilePath = $tempFolder.DIRECTORY_SEPARATOR.Str::slug("ctx-{$context}-{$userName}-{$url}-{$fileName}");
+        $tempFilePath = $tempFolder.DIRECTORY_SEPARATOR.Str::slug("ctx-{$context}-{$userName}-{$url}")."-{$fileName}";
 
         if (file_exists($tempFilePath)) {
             return $tempFilePath;

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -11,6 +11,8 @@ use RenokiCo\PhpK8s\KubernetesCluster;
 
 class KubeConfigTest extends TestCase
 {
+    private $tempFolder;
+
     /**
      * {@inheritdoc}
      */
@@ -18,7 +20,8 @@ class KubeConfigTest extends TestCase
     {
         parent::setUp();
 
-        KubernetesCluster::setTempFolder(__DIR__.DIRECTORY_SEPARATOR.'temp');
+        $this->tempFolder = __DIR__.DIRECTORY_SEPARATOR.'temp';
+        KubernetesCluster::setTempFolder($this->tempFolder);
     }
 
     /**
@@ -40,6 +43,12 @@ class KubeConfigTest extends TestCase
             'cert' => $certPath,
             'ssl_key' => $keyPath,
         ] = $cluster->getClient()->getConfig();
+
+        $tempFilePath = $this->tempFolder.DIRECTORY_SEPARATOR.'ctx-minikube-minikube-httpsminikube8443-';
+
+        $this->assertSame($tempFilePath.'ca-cert.pem', $caPath);
+        $this->assertSame($tempFilePath.'client-cert.pem', $certPath);
+        $this->assertSame($tempFilePath.'client-key.pem', $keyPath);
 
         $this->assertEquals("some-ca\n", file_get_contents($caPath));
         $this->assertEquals("some-cert\n", file_get_contents($certPath));


### PR DESCRIPTION
With the merging of #182 i think an unintentional bug was introduced in the temp certificate filename. The `$fileName` is included in the `Str::slug` function parameter, causing the certificate filename to lose the dot of the file extension.

before: `ctx-minikube-ca-cert.pem`
now: `ctx-minikube-minikube-httpsminikube8443-ca-certpem`
after fix: `ctx-minikube-minikube-httpsminikube8443-ca-cert.pem`

i have additionally added a few extra assertions to the `test_kube_config_from_yaml_file_with_base64_encoded_ssl` unittest to check the generated filename.