### PR TITLE
[fix] Added support for cmd-like auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "illuminate/macroable": "^8.83|^9.0.1",
         "illuminate/support": "^8.83|^9.0.1",
         "ratchet/pawl": "^0.4.1",
+        "symfony/process": "^5.4|^6.0",
         "vierbergenlars/php-semver": "^2.1|^3.0"
     },
     "suggest": {

--- a/src/Kinds/K8sPod.php
+++ b/src/Kinds/K8sPod.php
@@ -399,7 +399,7 @@ class K8sPod extends K8sResource implements
      *
      * @param  string  $containerName
      * @param  bool  $asInstance
-     * @return array|null
+     * @return \RenokiCo\PhpK8s\Instances\Container|array|null
      */
     public function getContainer(string $containerName, bool $asInstance = true)
     {

--- a/src/Traits/Cluster/LoadsFromKubeConfig.php
+++ b/src/Traits/Cluster/LoadsFromKubeConfig.php
@@ -218,6 +218,16 @@ trait LoadsFromKubeConfig
             $this->withToken($userConfig['user']['auth-provider']['config']['access-token']);
         }
 
+        if (isset($userConfig['user']['auth-provider']['config']['cmd-path'])) {
+            $authProviderConfig = $userConfig['user']['auth-provider']['config'];
+
+            $this->withTokenFromCommandProvider(
+                $authProviderConfig['cmd-path'],
+                $authProviderConfig['cmd-args'] ?? null,
+                $authProviderConfig['token-key'] ?? null,
+            );
+        }
+
         if (isset($clusterConfig['cluster']['insecure-skip-tls-verify']) && $clusterConfig['cluster']['insecure-skip-tls-verify']) {
             $this->withoutSslChecks();
         }

--- a/src/Traits/Cluster/MakesHttpCalls.php
+++ b/src/Traits/Cluster/MakesHttpCalls.php
@@ -38,6 +38,7 @@ trait MakesHttpCalls
         $options = [
             RequestOptions::HEADERS => [
                 'Content-Type' => 'application/json',
+                'Accept-Encoding' => 'gzip, deflate',
             ],
             RequestOptions::VERIFY => true,
         ];

--- a/tests/ClusterRoleBindingTest.php
+++ b/tests/ClusterRoleBindingTest.php
@@ -19,7 +19,7 @@ class ClusterRoleBindingTest extends TestCase
             ->addVerbs(['get', 'list', 'watch']);
 
         $cr = $this->cluster->clusterRole()
-            ->setName('admin-cr')
+            ->setName('admin-cr-for-binding')
             ->setLabels(['tier' => 'backend'])
             ->addRules([$rule]);
 
@@ -39,7 +39,7 @@ class ClusterRoleBindingTest extends TestCase
         $this->assertEquals('user-binding', $crb->getName());
         $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
-        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
+        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr-for-binding'], $crb->getRole());
     }
 
     public function test_cluster_role_binding_from_yaml()
@@ -51,7 +51,7 @@ class ClusterRoleBindingTest extends TestCase
             ->addVerbs(['get', 'list', 'watch']);
 
         $cr = $this->cluster->clusterRole()
-            ->setName('admin-cr')
+            ->setName('admin-cr-for-binding')
             ->setLabels(['tier' => 'backend'])
             ->addRules([$rule]);
 
@@ -66,7 +66,7 @@ class ClusterRoleBindingTest extends TestCase
         $this->assertEquals('user-binding', $crb->getName());
         $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
-        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
+        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr-for-binding'], $crb->getRole());
     }
 
     public function test_cluster_role_binding_api_interaction()
@@ -89,7 +89,7 @@ class ClusterRoleBindingTest extends TestCase
             ->addVerbs(['get', 'list', 'watch']);
 
         $cr = $this->cluster->clusterRole()
-            ->setName('admin-cr')
+            ->setName('admin-cr-for-binding')
             ->setLabels(['tier' => 'backend'])
             ->addRules([$rule]);
 
@@ -120,7 +120,7 @@ class ClusterRoleBindingTest extends TestCase
         $this->assertEquals('user-binding', $crb->getName());
         $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
-        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
+        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr-for-binding'], $crb->getRole());
     }
 
     public function runGetAllTests()
@@ -143,7 +143,7 @@ class ClusterRoleBindingTest extends TestCase
             ->setKind('User')
             ->setName('user-1');
 
-        $cr = $this->cluster->getClusterRoleByName('admin-cr');
+        $cr = $this->cluster->getClusterRoleByName('admin-cr-for-binding');
         $crb = $this->cluster->getClusterRoleBindingByName('user-binding');
 
         $this->assertInstanceOf(K8sClusterRoleBinding::class, $crb);
@@ -154,12 +154,12 @@ class ClusterRoleBindingTest extends TestCase
         $this->assertEquals('user-binding', $crb->getName());
         $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
-        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
+        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr-for-binding'], $crb->getRole());
     }
 
     public function runUpdateTests()
     {
-        $cr = $this->cluster->getClusterRoleByName('admin-cr');
+        $cr = $this->cluster->getClusterRoleByName('admin-cr-for-binding');
         $crb = $this->cluster->getClusterRoleBindingByName('user-binding');
 
         $subject = K8s::subject()
@@ -179,12 +179,12 @@ class ClusterRoleBindingTest extends TestCase
         $this->assertEquals('user-binding', $crb->getName());
         $this->assertEquals(['tier' => 'backend'], $crb->getLabels());
         $this->assertEquals([$subject], $crb->getSubjects());
-        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr'], $crb->getRole());
+        $this->assertEquals(['apiGroup' => 'rbac.authorization.k8s.io', 'kind' => 'ClusterRole', 'name' => 'admin-cr-for-binding'], $crb->getRole());
     }
 
     public function runDeletionTests()
     {
-        $cr = $this->cluster->getClusterRoleByName('admin-cr');
+        $cr = $this->cluster->getClusterRoleByName('admin-cr-for-binding');
         $crb = $this->cluster->getClusterRoleBindingByName('user-binding');
 
         $this->assertTrue($cr->delete());
@@ -200,7 +200,7 @@ class ClusterRoleBindingTest extends TestCase
 
         $this->expectException(KubernetesAPIException::class);
 
-        $this->cluster->getClusterRoleByName('admin-cr');
+        $this->cluster->getClusterRoleByName('admin-cr-for-binding');
         $this->cluster->getClusterRoleBindingByName('user-binding');
     }
 

--- a/tests/KubeConfigTest.php
+++ b/tests/KubeConfigTest.php
@@ -241,4 +241,22 @@ class KubeConfigTest extends TestCase
         $this->assertEquals("some-cert\n", file_get_contents($certPath));
         $this->assertEquals("some-key\n", file_get_contents($keyPath));
     }
+
+    public function test_kube_config_from_yaml_file_with_cmd_auth_as_json()
+    {
+        $cluster = KubernetesCluster::fromKubeConfigYamlFile(__DIR__.'/cluster/kubeconfig-command.yaml', 'minikube');
+
+        ['headers' => ['authorization' => $token]] = $cluster->getClient()->getConfig();
+
+        $this->assertEquals('Bearer some-token', $token);
+    }
+
+    public function test_kube_config_from_yaml_file_with_cmd_auth_as_string()
+    {
+        $cluster = KubernetesCluster::fromKubeConfigYamlFile(__DIR__.'/cluster/kubeconfig-command.yaml', 'minikube-2');
+
+        ['headers' => ['authorization' => $token]] = $cluster->getClient()->getConfig();
+
+        $this->assertEquals('Bearer some-token', $token);
+    }
 }

--- a/tests/PodTest.php
+++ b/tests/PodTest.php
@@ -111,7 +111,7 @@ class PodTest extends TestCase
     public function test_pod_exec()
     {
         $busybox = K8s::container()
-            ->setName('busybox')
+            ->setName('busybox-exec')
             ->setImage('busybox')
             ->setCommand(['/bin/sh', '-c', 'sleep 7200']);
 
@@ -126,7 +126,7 @@ class PodTest extends TestCase
             $pod->refresh();
         }
 
-        $messages = $pod->exec(['/bin/sh', '-c', 'echo 1 && echo 2 && echo 3'], 'busybox');
+        $messages = $pod->exec(['/bin/sh', '-c', 'echo 1 && echo 2 && echo 3'], 'busybox-exec');
 
         $hasDesiredOutput = collect($messages)->where('channel', 'stdout')->filter(function ($message) {
             return Str::contains($message['output'], '1')
@@ -142,7 +142,7 @@ class PodTest extends TestCase
     public function test_pod_attach()
     {
         $mysql = K8s::container()
-            ->setName('mysql')
+            ->setName('mysql-attach')
             ->setImage('mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
@@ -150,7 +150,7 @@ class PodTest extends TestCase
             ->setEnv(['MYSQL_ROOT_PASSWORD' => 'test']);
 
         $pod = $this->cluster->pod()
-            ->setName('mysql-exec')
+            ->setName('mysql-attach')
             ->setContainers([$mysql])
             ->createOrUpdate();
 

--- a/tests/cluster/kubeconfig-command.yaml
+++ b/tests/cluster/kubeconfig-command.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: c29tZS1jYQo= # "some-ca"
+    server: https://minikube:8443
+  name: minikube
+- cluster:
+    certificate-authority-data: c29tZS1jYQo= # "some-ca"
+    server: https://minikube:8443
+  name: minikube-2
+contexts:
+- context:
+    cluster: minikube
+    user: minikube
+  name: minikube
+- context:
+    cluster: minikube-2
+    user: minikube-2
+  name: minikube-2
+current-context: minikube
+kind: Config
+preferences: {}
+users:
+- name: minikube
+  user:
+    auth-provider:
+      config:
+        cmd-args: ''
+        cmd-path: 'echo { "nested": { "token": "some-token" } }'
+        token-key: '{.nested.token}'
+- name: minikube-2
+  user:
+    auth-provider:
+      config:
+        cmd-path: 'echo some-token'

--- a/tests/cluster/kubeconfig-command.yaml
+++ b/tests/cluster/kubeconfig-command.yaml
@@ -26,7 +26,7 @@ users:
     auth-provider:
       config:
         cmd-args: ''
-        cmd-path: 'echo { "nested": { "token": "some-token" } }'
+        cmd-path: cat tests/cluster/token.json
         token-key: '{.nested.token}'
 - name: minikube-2
   user:

--- a/tests/cluster/token.json
+++ b/tests/cluster/token.json
@@ -1,0 +1,5 @@
+{
+    "nested": {
+        "token": "some-token"
+    }
+}

--- a/tests/yaml/clusterrolebinding.yaml
+++ b/tests/yaml/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: admin-cr
+  name: admin-cr-for-binding
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User


### PR DESCRIPTION
Some clusters like GKE authenticates users by renewing a token at specific intervals. For example, in the following kubeconfig file, the user token in `kubectl` is taken from a CLI response:

```yaml
users:
- name: gke_cluster
    user:
        auth-provider:
            config:
                cmd-args: config config-helper --format=json
                cmd-path: S:\GCSDK\google-cloud-sdk\bin\gcloud.cmd
                expiry-key: '{.credential.token_expiry}'
                token-key: '{.credential.access_token}'
            name: gcp
```

With this PR, the package will run the `cmd-path` and `cmd-args` with Symfony Process to retrieve the token and authenticate the requests.