### PR TITLE
[upgrade] Bump minikube, k8s, PHP and Laravel versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
           - '8.1'
           - '8.2'
         kubernetes:
-          - '1.23.16'
-          - '1.24.10'
-          - '1.25.6'
+          - '1.24.12'
+          - '1.25.8'
+          - '1.26.3'
         laravel:
           - 9.*
           - 10.*
@@ -63,12 +63,12 @@ jobs:
         path: ~/.composer/cache/files
         key: composer-php-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.prefer }}-${{ hashFiles('composer.json') }}
 
-    - uses: manusa/actions-setup-minikube@v2.7.2
+    - uses: medyagh/setup-minikube@latest
       name: Setup Minikube
       with:
-        minikube version: v1.29.0
-        kubernetes version: "v${{ matrix.kubernetes }}"
-        github token: "${{ secrets.GITHUB_TOKEN }}"
+        minikube-version: 1.29.0
+        container-runtime: containerd
+        kubernetes-version: "v${{ matrix.kubernetes }}"
 
     - name: Run Kubernetes Proxy
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,27 @@ jobs:
         php:
           - '8.0'
           - '8.1'
+          - '8.2'
         kubernetes:
-          - '1.22.9'
-          - '1.23.6'
-          - '1.24.0'
+          - '1.23.16'
+          - '1.24.10'
+          - '1.25.6'
         laravel:
           - 9.*
+          - 10.*
         prefer:
           - 'prefer-lowest'
           - 'prefer-stable'
         include:
+          - laravel: 10.*
+            testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
+        exclude:
+          - laravel: 10.*
+            php: '8.0'
+          - laravel: 9.*
+            php: '8.2'
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}
 
@@ -53,10 +62,10 @@ jobs:
         path: ~/.composer/cache/files
         key: composer-php-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.prefer }}-${{ hashFiles('composer.json') }}
 
-    - uses: manusa/actions-setup-minikube@v2.6.1
+    - uses: manusa/actions-setup-minikube@v2.7.2
       name: Setup Minikube
       with:
-        minikube version: v1.25.2
+        minikube version: v1.29.0
         kubernetes version: "v${{ matrix.kubernetes }}"
         github token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -79,7 +88,7 @@ jobs:
 
     - name: Setting CRDs for testing
       run: |
-        kubectl apply -f https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/main/helm/sealed-secrets/crds/sealedsecret-crd.yaml
+        kubectl apply -f https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/main/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
 
     # - name: Run static analysis
     #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.0'
           - '8.1'
           - '8.2'
         kubernetes:
@@ -35,15 +34,10 @@ jobs:
           - 'prefer-lowest'
           - 'prefer-stable'
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
-        exclude:
           - laravel: 10.*
-            php: '8.0'
-          - laravel: 9.*
-            php: '8.2'
+            testbench: 8.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install dependencies
       run: |
         composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-        composer update --${{ matrix.prefer }} --prefer-dist --no-interaction --no-suggest
+        composer update --${{ matrix.prefer }} --prefer-dist --no-interaction
 
     - name: Setup in-cluster config
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.22.9 K8s Version](https://img.shields.io/badge/K8s%20v1.22.9-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.23.6 K8s Version](https://img.shields.io/badge/K8s%20v1.23.6-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.24.0 K8s Version](https://img.shields.io/badge/K8s%20v1.24.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.23.16 K8s Version](https://img.shields.io/badge/K8s%20v1.23.16-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.24.10 K8s Version](https://img.shields.io/badge/K8s%20v1.24.10-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.25.6 K8s Version](https://img.shields.io/badge/K8s%20v1.25.6-Ready-%23326ce5?colorA=306CE8&colorB=green)
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.23.16 K8s Version](https://img.shields.io/badge/K8s%20v1.23.16-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.24.10 K8s Version](https://img.shields.io/badge/K8s%20v1.24.10-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.25.6 K8s Version](https://img.shields.io/badge/K8s%20v1.25.6-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.24.12 K8s Version](https://img.shields.io/badge/K8s%20v1.24.12-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.25.8 K8s Version](https://img.shields.io/badge/K8s%20v1.25.8-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.26.3 K8s Version](https://img.shields.io/badge/K8s%20v1.26.3-Ready-%23326ce5?colorA=306CE8&colorB=green)
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)
 

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "illuminate/support": "^9.0.1|^10.0.0",
         "ratchet/pawl": "^0.4.1",
         "symfony/process": "^5.4|^6.0",
-        "vierbergenlars/php-semver": "^2.1|^3.0"
+        "vierbergenlars/php-semver": "^2.1|^3.0",
+        "ext-yaml": "*"
     },
     "suggest": {
-        "ext-yaml": "YAML extension is used to read or generate YAML from PHP K8s internal classes."
     },
     "autoload": {
         "psr-4": {
@@ -37,7 +37,6 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^7.0|^8.0",
         "orchestra/testbench-core": "^7.0|^8.0",
         "phpunit/phpunit": "^9.5.20|^10.0",
         "vimeo/psalm": "^4.20"

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "^6.5|^7.0",
-        "illuminate/macroable": "^9.0.1",
-        "illuminate/support": "^9.0.1",
+        "illuminate/macroable": "^9.0.1|^10.0.0",
+        "illuminate/support": "^9.0.1|^10.0.0",
         "ratchet/pawl": "^0.4.1",
         "symfony/process": "^5.4|^6.0",
         "vierbergenlars/php-semver": "^2.1|^3.0"
@@ -37,9 +37,9 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^6.28|^7.0",
-        "orchestra/testbench-core": "^6.28|^7.0",
-        "phpunit/phpunit": "^9.5.20",
+        "orchestra/testbench": "^7.0|^8.0",
+        "orchestra/testbench-core": "^7.0|^8.0",
+        "phpunit/phpunit": "^9.5.20|^10.0",
         "vimeo/psalm": "^4.20"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench-core": "^7.23|^8.1",
+        "orchestra/testbench": "^7.23|^8.1",
         "phpunit/phpunit": "^9.5.20|^10.0",
         "vimeo/psalm": "^4.20"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         }
     ],
     "require": {
+        "ext-yaml": "*",
         "guzzlehttp/guzzle": "^6.5|^7.0",
-        "illuminate/macroable": "^9.0.1|^10.0.0",
-        "illuminate/support": "^9.0.1|^10.0.0",
+        "illuminate/macroable": "^9.35|^10.1",
+        "illuminate/support": "^9.35|^10.1",
         "ratchet/pawl": "^0.4.1",
         "symfony/process": "^5.4|^6.0",
-        "vierbergenlars/php-semver": "^2.1|^3.0",
-        "ext-yaml": "*"
+        "vierbergenlars/php-semver": "^2.1|^3.0"
     },
     "suggest": {
     },
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench-core": "^7.0|^8.0",
+        "orchestra/testbench-core": "^7.23|^8.1",
         "phpunit/phpunit": "^9.5.20|^10.0",
         "vimeo/psalm": "^4.20"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Renoki Co Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <server name="APP_ENV" value="testing" />
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Renoki Co Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_ENV" value="testing"/>
+  </php>
 </phpunit>

--- a/src/Kinds/K8sCronJob.php
+++ b/src/Kinds/K8sCronJob.php
@@ -4,6 +4,8 @@ namespace RenokiCo\PhpK8s\Kinds;
 
 use Carbon\Carbon;
 use Cron\CronExpression;
+use DateTime;
+use Illuminate\Support\Collection;
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
 use RenokiCo\PhpK8s\Traits\Resource\HasSpec;
@@ -26,7 +28,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
      *
      * @var string
      */
-    protected static $defaultVersion = 'batch/v1beta1';
+    protected static $defaultVersion = 'batch/v1';
 
     /**
      * Wether the resource has a namespace.
@@ -38,7 +40,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
     /**
      * Set the job template.
      *
-     * @param  array|\RenokiCo\PhpK8s\Kinds\K8sJob  $job
+     * @param  array|K8sJob $job
      * @return $this
      */
     public function setJobTemplate($job)
@@ -54,7 +56,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
      * Get the template job.
      *
      * @param  bool  $asInstance
-     * @return array|\RenokiCo\PhpK8s\Kinds\K8sJob
+     * @return array|K8sJob
      */
     public function getJobTemplate(bool $asInstance = true)
     {
@@ -70,7 +72,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
     /**
      * Set the schedule for the cronjob.
      *
-     * @param  \Cron\CronExpression|string  $schedule
+     * @param CronExpression|string  $schedule
      * @return $this
      */
     public function setSchedule($schedule)
@@ -86,7 +88,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
      * Retrieve the schedule.
      *
      * @param  bool  $asInstance
-     * @return \Cron\CronExpression|string
+     * @return CronExpression|string
      */
     public function getSchedule(bool $asInstance = true)
     {
@@ -102,7 +104,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
     /**
      * Get the last time a job was scheduled.
      *
-     * @return \DateTime|null
+     * @return DateTime|null
      */
     public function getLastSchedule()
     {
@@ -116,7 +118,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
     /**
      * Get the active jobs created by the cronjob.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function getActiveJobs()
     {

--- a/src/Kinds/K8sCronJob.php
+++ b/src/Kinds/K8sCronJob.php
@@ -123,7 +123,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
     public function getActiveJobs()
     {
         return collect($this->getStatus('active', []))->map(function ($job) {
-            return $this->cluster->job($job)->refresh();
+            return $this->cluster->getJobByName($job['name'], $this->getNamespace());
         });
     }
 }

--- a/src/Kinds/K8sCronJob.php
+++ b/src/Kinds/K8sCronJob.php
@@ -40,7 +40,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
     /**
      * Set the job template.
      *
-     * @param  array|K8sJob $job
+     * @param  array|K8sJob  $job
      * @return $this
      */
     public function setJobTemplate($job)
@@ -72,7 +72,7 @@ class K8sCronJob extends K8sResource implements InteractsWithK8sCluster, Watchab
     /**
      * Set the schedule for the cronjob.
      *
-     * @param CronExpression|string  $schedule
+     * @param  CronExpression|string  $schedule
      * @return $this
      */
     public function setSchedule($schedule)

--- a/src/Kinds/K8sHorizontalPodAutoscaler.php
+++ b/src/Kinds/K8sHorizontalPodAutoscaler.php
@@ -40,7 +40,7 @@ class K8sHorizontalPodAutoscaler extends K8sResource implements InteractsWithK8s
     /**
      * Set the reference to the scaling resource.
      *
-     * @param Scalable $resource
+     * @param  Scalable  $resource
      * @return $this
      */
     public function setResource(Scalable $resource)
@@ -55,7 +55,7 @@ class K8sHorizontalPodAutoscaler extends K8sResource implements InteractsWithK8s
     /**
      * Add a new metric.
      *
-     * @param ResourceMetric $metric
+     * @param  ResourceMetric  $metric
      * @return $this
      */
     public function addMetric(ResourceMetric $metric)

--- a/src/Kinds/K8sHorizontalPodAutoscaler.php
+++ b/src/Kinds/K8sHorizontalPodAutoscaler.php
@@ -28,7 +28,7 @@ class K8sHorizontalPodAutoscaler extends K8sResource implements InteractsWithK8s
      *
      * @var string
      */
-    protected static $defaultVersion = 'autoscaling/v2beta2';
+    protected static $defaultVersion = 'autoscaling/v2';
 
     /**
      * Wether the resource has a namespace.
@@ -40,7 +40,7 @@ class K8sHorizontalPodAutoscaler extends K8sResource implements InteractsWithK8s
     /**
      * Set the reference to the scaling resource.
      *
-     * @param  \RenokiCo\PhpK8s\Contracts\Scalable  $resource
+     * @param Scalable $resource
      * @return $this
      */
     public function setResource(Scalable $resource)
@@ -55,7 +55,7 @@ class K8sHorizontalPodAutoscaler extends K8sResource implements InteractsWithK8s
     /**
      * Add a new metric.
      *
-     * @param  \RenokiCo\PhpK8s\Instances\ResourceMetric  $metric
+     * @param ResourceMetric $metric
      * @return $this
      */
     public function addMetric(ResourceMetric $metric)

--- a/src/Kinds/K8sJob.php
+++ b/src/Kinds/K8sJob.php
@@ -151,6 +151,6 @@ class K8sJob extends K8sResource implements
      */
     public function hasCompleted(): bool
     {
-        return !is_null($this->getCompletionTime());
+        return ! is_null($this->getCompletionTime());
     }
 }

--- a/src/Kinds/K8sJob.php
+++ b/src/Kinds/K8sJob.php
@@ -151,6 +151,6 @@ class K8sJob extends K8sResource implements
      */
     public function hasCompleted(): bool
     {
-        return $this->getActivePodsCount() === 0;
+        return !is_null($this->getCompletionTime());
     }
 }

--- a/src/Kinds/K8sPodDisruptionBudget.php
+++ b/src/Kinds/K8sPodDisruptionBudget.php
@@ -33,7 +33,7 @@ class K8sPodDisruptionBudget extends K8sResource implements InteractsWithK8sClus
      *
      * @var string
      */
-    protected static $defaultVersion = 'policy/v1beta1';
+    protected static $defaultVersion = 'policy/v1';
 
     /**
      * Set the maximum unavailable pod budget and

--- a/src/Kinds/K8sStatefulSet.php
+++ b/src/Kinds/K8sStatefulSet.php
@@ -72,7 +72,7 @@ class K8sStatefulSet extends K8sResource implements
     /**
      * Set the statefulset service.
      *
-     * @param K8sService|string  $service
+     * @param  K8sService|string  $service
      * @return $this
      */
     public function setService($service)

--- a/src/Kinds/K8sStatefulSet.php
+++ b/src/Kinds/K8sStatefulSet.php
@@ -72,7 +72,7 @@ class K8sStatefulSet extends K8sResource implements
     /**
      * Set the statefulset service.
      *
-     * @param  \RenokiCo\PhpK8s\Kinds\K8sService|string  $service
+     * @param K8sService|string  $service
      * @return $this
      */
     public function setService($service)
@@ -97,7 +97,7 @@ class K8sStatefulSet extends K8sResource implements
     /**
      * Get the K8sService instance.
      *
-     * @return null|\RenokiCo\PhpK8s\Kinds\K8sService
+     * @return null|K8sService
      */
     public function getServiceInstance()
     {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -14,7 +14,7 @@ class ContainerTest extends TestCase
 
         $volume = K8s::volume()->awsEbs('vol-1234', 'ext3');
 
-        $container->setImage('nginx', '1.4')
+        $container->setImage('public.ecr.aws/docker/library/nginx', '1.23')
             ->setEnv(['key' => 'value'])
             ->addEnvs(['key2' => 'value2'])
             ->addSecretKeyRefs(['SECRET_ONE' => ['secret_ref_name', 'secret_ref_key']])
@@ -55,7 +55,7 @@ class ContainerTest extends TestCase
                 ->setSuccessThreshold(2)
         );
 
-        $this->assertEquals('nginx:1.4', $container->getImage());
+        $this->assertStringEndsWith('nginx:1.23', $container->getImage());
         $this->assertEquals([
             ['name' => 'key', 'value' => 'value'],
             ['name' => 'key2', 'value' => 'value2'],
@@ -95,7 +95,7 @@ class ContainerTest extends TestCase
         $container->removeEnv();
 
         $this->assertFalse($container->isReady());
-        $this->assertEquals('nginx:1.4', $container->getImage());
+        $this->assertStringEndsWith('nginx:1.23', $container->getImage());
         $this->assertEquals([], $container->getEnv([]));
         $this->assertEquals(['--test'], $container->getArgs());
         $this->assertEquals([

--- a/tests/CronJobTest.php
+++ b/tests/CronJobTest.php
@@ -17,7 +17,7 @@ class CronCronJobTest extends TestCase
         $pi = K8s::container()
             ->setName('pi')
             ->setImage('public.ecr.aws/docker/library/perl')
-            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
+            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(200)']);
 
         $pod = $this->cluster->pod()
             ->setName('perl')
@@ -54,7 +54,7 @@ class CronCronJobTest extends TestCase
         $pi = K8s::container()
             ->setName('pi')
             ->setImage('public.ecr.aws/docker/library/perl')
-            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
+            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(200)']);
 
         $pod = $this->cluster->pod()
             ->setName('perl')
@@ -90,7 +90,7 @@ class CronCronJobTest extends TestCase
         $pi = K8s::container()
             ->setName('pi')
             ->setImage('public.ecr.aws/docker/library/perl', '5.36.0')
-            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
+            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(200)']);
 
         $pod = $this->cluster->pod()
             ->setName('perl')

--- a/tests/CronJobTest.php
+++ b/tests/CronJobTest.php
@@ -39,7 +39,7 @@ class CronCronJobTest extends TestCase
             ->setJobTemplate($job)
             ->setSchedule(CronExpression::factory('* * * * *'));
 
-        $this->assertEquals('batch/v1beta1', $cronjob->getApiVersion());
+        $this->assertEquals('batch/v1', $cronjob->getApiVersion());
         $this->assertEquals('pi', $cronjob->getName());
         $this->assertEquals(['tier' => 'backend'], $cronjob->getLabels());
         $this->assertEquals(['perl/annotation' => 'yes'], $cronjob->getAnnotations());
@@ -64,7 +64,7 @@ class CronCronJobTest extends TestCase
 
         $cronjob = $this->cluster->fromYamlFile(__DIR__.'/yaml/cronjob.yaml');
 
-        $this->assertEquals('batch/v1beta1', $cronjob->getApiVersion());
+        $this->assertEquals('batch/v1', $cronjob->getApiVersion());
         $this->assertEquals('pi', $cronjob->getName());
         $this->assertEquals(['tier' => 'backend'], $cronjob->getLabels());
         $this->assertEquals(['perl/annotation' => 'yes'], $cronjob->getAnnotations());
@@ -122,7 +122,7 @@ class CronCronJobTest extends TestCase
 
         $this->assertInstanceOf(K8sCronJob::class, $cronjob);
 
-        $this->assertEquals('batch/v1beta1', $cronjob->getApiVersion());
+        $this->assertEquals('batch/v1', $cronjob->getApiVersion());
         $this->assertEquals('pi', $cronjob->getName());
         $this->assertEquals(['tier' => 'backend'], $cronjob->getLabels());
         $this->assertEquals(['perl/annotation' => 'yes'], $cronjob->getAnnotations());
@@ -175,7 +175,7 @@ class CronCronJobTest extends TestCase
 
         $this->assertTrue($cronjob->isSynced());
 
-        $this->assertEquals('batch/v1beta1', $cronjob->getApiVersion());
+        $this->assertEquals('batch/v1', $cronjob->getApiVersion());
         $this->assertEquals('pi', $cronjob->getName());
         $this->assertEquals(['tier' => 'backend'], $cronjob->getLabels());
         $this->assertEquals(['perl/annotation' => 'yes'], $cronjob->getAnnotations());
@@ -195,7 +195,7 @@ class CronCronJobTest extends TestCase
 
         $this->assertTrue($cronjob->isSynced());
 
-        $this->assertEquals('batch/v1beta1', $cronjob->getApiVersion());
+        $this->assertEquals('batch/v1', $cronjob->getApiVersion());
         $this->assertEquals('pi', $cronjob->getName());
         $this->assertEquals(['tier' => 'backend'], $cronjob->getLabels());
         $this->assertEquals([], $cronjob->getAnnotations());

--- a/tests/CronJobTest.php
+++ b/tests/CronJobTest.php
@@ -16,7 +16,7 @@ class CronCronJobTest extends TestCase
     {
         $pi = K8s::container()
             ->setName('pi')
-            ->setImage('perl')
+            ->setImage('public.ecr.aws/docker/library/perl')
             ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
 
         $pod = $this->cluster->pod()
@@ -53,7 +53,7 @@ class CronCronJobTest extends TestCase
     {
         $pi = K8s::container()
             ->setName('pi')
-            ->setImage('perl')
+            ->setImage('public.ecr.aws/docker/library/perl')
             ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
 
         $pod = $this->cluster->pod()
@@ -89,7 +89,7 @@ class CronCronJobTest extends TestCase
     {
         $pi = K8s::container()
             ->setName('pi')
-            ->setImage('perl', '5.34.0')
+            ->setImage('public.ecr.aws/docker/library/perl', '5.36.0')
             ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
 
         $pod = $this->cluster->pod()

--- a/tests/CronJobTest.php
+++ b/tests/CronJobTest.php
@@ -10,7 +10,7 @@ use RenokiCo\PhpK8s\Kinds\K8sCronJob;
 use RenokiCo\PhpK8s\Kinds\K8sJob;
 use RenokiCo\PhpK8s\ResourcesList;
 
-class CronCronJobTest extends TestCase
+class CronJobTest extends TestCase
 {
     public function test_cronjob_build()
     {
@@ -87,28 +87,28 @@ class CronCronJobTest extends TestCase
 
     public function runCreationTests()
     {
-        $pi = K8s::container()
-            ->setName('pi')
-            ->setImage('public.ecr.aws/docker/library/perl', '5.36.0')
-            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(200)']);
+        $busybox = K8s::container()
+            ->setName('busybox-exec')
+            ->setImage('public.ecr.aws/docker/library/busybox')
+            ->setCommand(['/bin/sh', '-c', 'sleep 30']);
 
         $pod = $this->cluster->pod()
-            ->setName('perl')
-            ->setContainers([$pi])
+            ->setName('sleep')
+            ->setContainers([$busybox])
             ->restartOnFailure()
             ->neverRestart();
 
         $job = $this->cluster->job()
-            ->setName('pi')
-            ->setLabels(['tier' => 'backend'])
-            ->setAnnotations(['perl/annotation' => 'yes'])
+            ->setName('sleeper')
+            ->setLabels(['tier' => 'useless'])
+            ->setAnnotations(['perl/annotation' => 'no'])
             ->setTTL(3600)
             ->setTemplate($pod);
 
         $cronjob = $this->cluster->cronjob()
-            ->setName('pi')
-            ->setLabels(['tier' => 'backend'])
-            ->setAnnotations(['perl/annotation' => 'yes'])
+            ->setName('periodic-sleep')
+            ->setLabels(['tier' => 'useless'])
+            ->setAnnotations(['perl/annotation' => 'no'])
             ->setJobTemplate($job)
             ->setSchedule(CronExpression::factory('* * * * *'));
 
@@ -123,9 +123,9 @@ class CronCronJobTest extends TestCase
         $this->assertInstanceOf(K8sCronJob::class, $cronjob);
 
         $this->assertEquals('batch/v1', $cronjob->getApiVersion());
-        $this->assertEquals('pi', $cronjob->getName());
-        $this->assertEquals(['tier' => 'backend'], $cronjob->getLabels());
-        $this->assertEquals(['perl/annotation' => 'yes'], $cronjob->getAnnotations());
+        $this->assertEquals('periodic-sleep', $cronjob->getName());
+        $this->assertEquals(['tier' => 'useless'], $cronjob->getLabels());
+        $this->assertEquals(['perl/annotation' => 'no'], $cronjob->getAnnotations());
         $this->assertEquals('Never', $pod->getRestartPolicy());
 
         $this->assertInstanceOf(K8sJob::class, $cronjob->getJobTemplate());
@@ -135,6 +135,7 @@ class CronCronJobTest extends TestCase
 
         $activeJobs = $cronjob->getActiveJobs();
 
+        // This check is sensitive to ensuring the jobs take some time to complete.
         while ($cronjob->getActiveJobs()->count() === 0) {
             dump("Waiting for the cronjob {$cronjob->getName()} to have active jobs...");
             sleep(1);
@@ -169,23 +170,23 @@ class CronCronJobTest extends TestCase
 
     public function runGetTests()
     {
-        $cronjob = $this->cluster->getCronJobByName('pi');
+        $cronjob = $this->cluster->getCronJobByName('periodic-sleep');
 
         $this->assertInstanceOf(K8sCronJob::class, $cronjob);
 
         $this->assertTrue($cronjob->isSynced());
 
         $this->assertEquals('batch/v1', $cronjob->getApiVersion());
-        $this->assertEquals('pi', $cronjob->getName());
-        $this->assertEquals(['tier' => 'backend'], $cronjob->getLabels());
-        $this->assertEquals(['perl/annotation' => 'yes'], $cronjob->getAnnotations());
+        $this->assertEquals('periodic-sleep', $cronjob->getName());
+        $this->assertEquals(['tier' => 'useless'], $cronjob->getLabels());
+        $this->assertEquals(['perl/annotation' => 'no'], $cronjob->getAnnotations());
 
         $this->assertInstanceOf(K8sJob::class, $cronjob->getJobTemplate());
     }
 
     public function runUpdateTests()
     {
-        $cronjob = $this->cluster->getCronJobByName('pi');
+        $cronjob = $this->cluster->getCronJobByName('periodic-sleep');
 
         $this->assertTrue($cronjob->isSynced());
 
@@ -196,8 +197,8 @@ class CronCronJobTest extends TestCase
         $this->assertTrue($cronjob->isSynced());
 
         $this->assertEquals('batch/v1', $cronjob->getApiVersion());
-        $this->assertEquals('pi', $cronjob->getName());
-        $this->assertEquals(['tier' => 'backend'], $cronjob->getLabels());
+        $this->assertEquals('periodic-sleep', $cronjob->getName());
+        $this->assertEquals(['tier' => 'useless'], $cronjob->getLabels());
         $this->assertEquals([], $cronjob->getAnnotations());
 
         $this->assertInstanceOf(K8sJob::class, $cronjob->getJobTemplate());
@@ -205,7 +206,7 @@ class CronCronJobTest extends TestCase
 
     public function runDeletionTests()
     {
-        $cronjob = $this->cluster->getCronJobByName('pi');
+        $cronjob = $this->cluster->getCronJobByName('periodic-sleep');
 
         $this->assertTrue($cronjob->delete());
 
@@ -216,13 +217,13 @@ class CronCronJobTest extends TestCase
 
         $this->expectException(KubernetesAPIException::class);
 
-        $this->cluster->getCronJobByName('pi');
+        $this->cluster->getCronJobByName('periodic-sleep');
     }
 
     public function runWatchAllTests()
     {
         $watch = $this->cluster->cronjob()->watchAll(function ($type, $cronjob) {
-            if ($cronjob->getName() === 'pi') {
+            if ($cronjob->getName() === 'periodic-sleep') {
                 return true;
             }
         }, ['timeoutSeconds' => 10]);
@@ -232,8 +233,8 @@ class CronCronJobTest extends TestCase
 
     public function runWatchTests()
     {
-        $watch = $this->cluster->cronjob()->watchByName('pi', function ($type, $cronjob) {
-            return $cronjob->getName() === 'pi';
+        $watch = $this->cluster->cronjob()->watchByName('periodic-sleep', function ($type, $cronjob) {
+            return $cronjob->getName() === 'periodic-sleep';
         }, ['timeoutSeconds' => 10]);
 
         $this->assertTrue($watch);

--- a/tests/DaemonSetTest.php
+++ b/tests/DaemonSetTest.php
@@ -14,7 +14,7 @@ class DaemonSetTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ]);
@@ -43,7 +43,7 @@ class DaemonSetTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ]);
@@ -77,7 +77,7 @@ class DaemonSetTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])

--- a/tests/DeploymentTest.php
+++ b/tests/DeploymentTest.php
@@ -14,7 +14,7 @@ class DeploymentTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ]);
@@ -44,7 +44,7 @@ class DeploymentTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ]);
@@ -82,7 +82,7 @@ class DeploymentTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -23,7 +23,7 @@ class EventTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])

--- a/tests/HorizontalPodAutoscalerTest.php
+++ b/tests/HorizontalPodAutoscalerTest.php
@@ -42,7 +42,7 @@ class HorizontalPodAutoscalerTest extends TestCase
             ->min(1)
             ->max(10);
 
-        $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
+        $this->assertEquals('autoscaling/v2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
         $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
@@ -74,7 +74,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $hpa = $this->cluster->fromYamlFile(__DIR__.'/yaml/hpa.yaml');
 
-        $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
+        $this->assertEquals('autoscaling/v2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
         $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
@@ -141,7 +141,7 @@ class HorizontalPodAutoscalerTest extends TestCase
         $this->assertInstanceOf(K8sDeployment::class, $dep);
         $this->assertInstanceOf(K8sHorizontalPodAutoscaler::class, $hpa);
 
-        $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
+        $this->assertEquals('autoscaling/v2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
         $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
@@ -203,7 +203,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $cpuMetric = K8s::metric()->cpu()->averageUtilization(70);
 
-        $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
+        $this->assertEquals('autoscaling/v2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
         $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());
@@ -231,7 +231,7 @@ class HorizontalPodAutoscalerTest extends TestCase
 
         $cpuMetric = K8s::metric()->cpu()->averageUtilization(70);
 
-        $this->assertEquals('autoscaling/v2beta2', $hpa->getApiVersion());
+        $this->assertEquals('autoscaling/v2', $hpa->getApiVersion());
         $this->assertEquals('mysql-hpa', $hpa->getName());
         $this->assertEquals(['tier' => 'backend'], $hpa->getLabels());
         $this->assertEquals([$cpuMetric->toArray()], $hpa->getMetrics());

--- a/tests/HorizontalPodAutoscalerTest.php
+++ b/tests/HorizontalPodAutoscalerTest.php
@@ -15,7 +15,7 @@ class HorizontalPodAutoscalerTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ]);
@@ -54,7 +54,7 @@ class HorizontalPodAutoscalerTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ]);
@@ -97,7 +97,7 @@ class HorizontalPodAutoscalerTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -130,6 +130,7 @@ class JobTest extends TestCase
 
         K8sJob::selectPods(function ($job) {
             $this->assertInstanceOf(K8sJob::class, $job);
+
             return ['tier' => 'compute'];
         });
 

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -110,10 +110,10 @@ class JobTest extends TestCase
         $this->assertEquals('pi', $job->getName());
         $this->assertEquals(['tier' => 'backend'], $job->getLabels());
 
-        if ($this->cluster->olderThan('1.23.0') || $this->cluster->newerThan('1.24.0')) {
-            $this->assertEquals(['perl/annotation' => 'yes'], $job->getAnnotations());
-        } else {
-            $this->assertEquals(['perl/annotation' => 'yes', 'batch.kubernetes.io/job-tracking' => ''], $job->getAnnotations());
+        $annotations = $job->getAnnotations();
+        foreach(['perl/annotation' => 'yes'] as $key => $value) {
+            $this->assertContains($key, array_keys($annotations), "Annotation $key missing");
+            $this->assertEquals($value, $annotations[$key]);
         }
 
         $this->assertEquals($pod->getName(), $job->getTemplate()->getName());
@@ -187,10 +187,10 @@ class JobTest extends TestCase
         $this->assertEquals('pi', $job->getName());
         $this->assertEquals(['tier' => 'backend'], $job->getLabels());
 
-        if ($this->cluster->olderThan('1.23.0') || $this->cluster->newerThan('1.24.0')) {
-            $this->assertEquals(['perl/annotation' => 'yes'], $job->getAnnotations());
-        } else {
-            $this->assertEquals(['perl/annotation' => 'yes', 'batch.kubernetes.io/job-tracking' => ''], $job->getAnnotations());
+        $annotations = $job->getAnnotations();
+        foreach(['perl/annotation' => 'yes'] as $key => $value) {
+            $this->assertContains($key, array_keys($annotations), "Annotation $key missing");
+            $this->assertEquals($value, $annotations[$key]);
         }
 
         $this->assertInstanceOf(K8sPod::class, $job->getTemplate());

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -15,7 +15,7 @@ class JobTest extends TestCase
         $pi = K8s::container()
             ->setName('pi')
             ->setImage('public.ecr.aws/docker/library/perl')
-            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
+            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(200)']);
 
         $pod = $this->cluster->pod()
             ->setName('perl')
@@ -45,7 +45,7 @@ class JobTest extends TestCase
         $pi = K8s::container()
             ->setName('pi')
             ->setImage('public.ecr.aws/docker/library/perl')
-            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
+            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(200)']);
 
         $pod = $this->cluster->pod()
             ->setName('perl')
@@ -80,8 +80,8 @@ class JobTest extends TestCase
     {
         $pi = K8s::container()
             ->setName('pi')
-            ->setImage('public.ecr.aws/docker/library/perl', '5.36.0')
-            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
+            ->setImage('public.ecr.aws/docker/library/perl', '5.36')
+            ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(200)']);
 
         $pod = $this->cluster->pod()
             ->setName('perl')

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -25,14 +25,14 @@ class JobTest extends TestCase
 
         $job = $this->cluster->job()
             ->setName('pi')
-            ->setLabels(['tier' => 'backend'])
+            ->setLabels(['tier' => 'compute'])
             ->setAnnotations(['perl/annotation' => 'yes'])
             ->setTTL(3600)
             ->setTemplate($pod);
 
         $this->assertEquals('batch/v1', $job->getApiVersion());
         $this->assertEquals('pi', $job->getName());
-        $this->assertEquals(['tier' => 'backend'], $job->getLabels());
+        $this->assertEquals(['tier' => 'compute'], $job->getLabels());
         $this->assertEquals(['perl/annotation' => 'yes'], $job->getAnnotations());
         $this->assertEquals($pod->getName(), $job->getTemplate()->getName());
         $this->assertEquals('Never', $pod->getRestartPolicy());
@@ -57,7 +57,7 @@ class JobTest extends TestCase
 
         $this->assertEquals('batch/v1', $job->getApiVersion());
         $this->assertEquals('pi', $job->getName());
-        $this->assertEquals(['tier' => 'backend'], $job->getLabels());
+        $this->assertEquals(['tier' => 'compute'], $job->getLabels());
         $this->assertEquals(['perl/annotation' => 'yes'], $job->getAnnotations());
         $this->assertEquals($pod->getName(), $job->getTemplate()->getName());
         $this->assertEquals('Never', $pod->getRestartPolicy());
@@ -85,13 +85,13 @@ class JobTest extends TestCase
 
         $pod = $this->cluster->pod()
             ->setName('perl')
-            ->setLabels(['tier' => 'backend'])
+            ->setLabels(['tier' => 'compute'])
             ->setContainers([$pi])
             ->neverRestart();
 
         $job = $this->cluster->job()
             ->setName('pi')
-            ->setLabels(['tier' => 'backend'])
+            ->setLabels(['tier' => 'compute'])
             ->setAnnotations(['perl/annotation' => 'yes'])
             ->setTTL(3600)
             ->setTemplate($pod);
@@ -108,7 +108,7 @@ class JobTest extends TestCase
 
         $this->assertEquals('batch/v1', $job->getApiVersion());
         $this->assertEquals('pi', $job->getName());
-        $this->assertEquals(['tier' => 'backend'], $job->getLabels());
+        $this->assertEquals(['tier' => 'compute'], $job->getLabels());
 
         $annotations = $job->getAnnotations();
         foreach (['perl/annotation' => 'yes'] as $key => $value) {
@@ -130,8 +130,7 @@ class JobTest extends TestCase
 
         K8sJob::selectPods(function ($job) {
             $this->assertInstanceOf(K8sJob::class, $job);
-
-            return ['tier' => 'backend'];
+            return ['tier' => 'compute'];
         });
 
         $pods = $job->getPods();
@@ -149,7 +148,7 @@ class JobTest extends TestCase
         $job->refresh();
 
         while (! $completionTime = $job->getCompletionTime()) {
-            dump("Waiting for the competion time report of {$job->getName()}...");
+            dump("Waiting for the completion time report of {$job->getName()}...");
             sleep(1);
             $job->refresh();
         }
@@ -185,7 +184,7 @@ class JobTest extends TestCase
 
         $this->assertEquals('batch/v1', $job->getApiVersion());
         $this->assertEquals('pi', $job->getName());
-        $this->assertEquals(['tier' => 'backend'], $job->getLabels());
+        $this->assertEquals(['tier' => 'compute'], $job->getLabels());
 
         $annotations = $job->getAnnotations();
         foreach (['perl/annotation' => 'yes'] as $key => $value) {
@@ -210,7 +209,7 @@ class JobTest extends TestCase
 
         $this->assertEquals('batch/v1', $job->getApiVersion());
         $this->assertEquals('pi', $job->getName());
-        $this->assertEquals(['tier' => 'backend'], $job->getLabels());
+        $this->assertEquals(['tier' => 'compute'], $job->getLabels());
 
         $this->assertInstanceOf(K8sPod::class, $job->getTemplate());
     }

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -14,7 +14,7 @@ class JobTest extends TestCase
     {
         $pi = K8s::container()
             ->setName('pi')
-            ->setImage('perl')
+            ->setImage('public.ecr.aws/docker/library/perl')
             ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
 
         $pod = $this->cluster->pod()
@@ -44,7 +44,7 @@ class JobTest extends TestCase
     {
         $pi = K8s::container()
             ->setName('pi')
-            ->setImage('perl')
+            ->setImage('public.ecr.aws/docker/library/perl')
             ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
 
         $pod = $this->cluster->pod()
@@ -80,7 +80,7 @@ class JobTest extends TestCase
     {
         $pi = K8s::container()
             ->setName('pi')
-            ->setImage('perl', '5.34.0')
+            ->setImage('public.ecr.aws/docker/library/perl', '5.36.0')
             ->setCommand(['perl',  '-Mbignum=bpi', '-wle', 'print bpi(2000)']);
 
         $pod = $this->cluster->pod()

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -211,7 +211,6 @@ class JobTest extends TestCase
         $this->assertEquals('batch/v1', $job->getApiVersion());
         $this->assertEquals('pi', $job->getName());
         $this->assertEquals(['tier' => 'backend'], $job->getLabels());
-        $this->assertEquals([], $job->getAnnotations());
 
         $this->assertInstanceOf(K8sPod::class, $job->getTemplate());
     }

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -111,7 +111,7 @@ class JobTest extends TestCase
         $this->assertEquals(['tier' => 'backend'], $job->getLabels());
 
         $annotations = $job->getAnnotations();
-        foreach(['perl/annotation' => 'yes'] as $key => $value) {
+        foreach (['perl/annotation' => 'yes'] as $key => $value) {
             $this->assertContains($key, array_keys($annotations), "Annotation $key missing");
             $this->assertEquals($value, $annotations[$key]);
         }
@@ -188,7 +188,7 @@ class JobTest extends TestCase
         $this->assertEquals(['tier' => 'backend'], $job->getLabels());
 
         $annotations = $job->getAnnotations();
-        foreach(['perl/annotation' => 'yes'] as $key => $value) {
+        foreach (['perl/annotation' => 'yes'] as $key => $value) {
             $this->assertContains($key, array_keys($annotations), "Annotation $key missing");
             $this->assertEquals($value, $annotations[$key]);
         }

--- a/tests/PersistentVolumeClaimTest.php
+++ b/tests/PersistentVolumeClaimTest.php
@@ -78,14 +78,16 @@ class PersistentVolumeClaimTest extends TestCase
         $this->assertEquals(['ReadWriteOnce'], $pvc->getAccessModes());
         $this->assertEquals('standard', $pvc->getStorageClass());
 
-        while (! $pvc->isBound()) {
-            dump("Waiting for PVC {$pvc->getName()} to be bound...");
-            sleep(1);
-            $pvc->refresh();
-        }
+        if ($standard->getVolumeBindingMode() == 'Immediate') {
+            while (!$pvc->isBound()) {
+                dump("Waiting for PVC {$pvc->getName()} to be bound...");
+                sleep(1);
+                $pvc->refresh();
+            }
 
-        $this->assertFalse($pvc->isAvailable());
-        $this->assertTrue($pvc->isBound());
+            $this->assertFalse($pvc->isAvailable());
+            $this->assertTrue($pvc->isBound());
+        }
     }
 
     public function runGetAllTests()

--- a/tests/PersistentVolumeClaimTest.php
+++ b/tests/PersistentVolumeClaimTest.php
@@ -79,7 +79,7 @@ class PersistentVolumeClaimTest extends TestCase
         $this->assertEquals('standard', $pvc->getStorageClass());
 
         if ($standard->getVolumeBindingMode() == 'Immediate') {
-            while (!$pvc->isBound()) {
+            while (! $pvc->isBound()) {
                 dump("Waiting for PVC {$pvc->getName()} to be bound...");
                 sleep(1);
                 $pvc->refresh();

--- a/tests/PodDisruptionBudgetTest.php
+++ b/tests/PodDisruptionBudgetTest.php
@@ -159,15 +159,16 @@ class PodDisruptionBudgetTest extends TestCase
                 $pdb = $this->cluster->getPodDisruptionBudgetByName('mysql-pdb')->setMinAvailable('25%')->createOrUpdate();
             } catch (KubernetesAPIException $e) {
                 if ($e->getCode() == 409) {
-                    sleep(2*$backoff);
+                    sleep(2 * $backoff);
                     $backoff++;
                 } else {
                     throw $e;
                 }
-                if ($backoff > 3)
+                if ($backoff > 3) {
                     break;
+                }
             }
-        } while (!isset($pdb));
+        } while (! isset($pdb));
 
         $this->assertTrue($pdb->isSynced());
 

--- a/tests/PodDisruptionBudgetTest.php
+++ b/tests/PodDisruptionBudgetTest.php
@@ -65,7 +65,7 @@ class PodDisruptionBudgetTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])

--- a/tests/PodDisruptionBudgetTest.php
+++ b/tests/PodDisruptionBudgetTest.php
@@ -20,7 +20,7 @@ class PodDisruptionBudgetTest extends TestCase
             ->setMinAvailable(1)
             ->setMaxUnavailable('25%');
 
-        $this->assertEquals('policy/v1beta1', $pdb->getApiVersion());
+        $this->assertEquals('policy/v1', $pdb->getApiVersion());
         $this->assertEquals('mysql-pdb', $pdb->getName());
         $this->assertEquals(['matchLabels' => ['tier' => 'backend']], $pdb->getSelectors());
         $this->assertEquals(['tier' => 'backend'], $pdb->getLabels());
@@ -33,7 +33,7 @@ class PodDisruptionBudgetTest extends TestCase
     {
         [$pdb1, $pdb2] = $this->cluster->fromYamlFile(__DIR__.'/yaml/pdb.yaml');
 
-        $this->assertEquals('policy/v1beta1', $pdb1->getApiVersion());
+        $this->assertEquals('policy/v1', $pdb1->getApiVersion());
         $this->assertEquals('mysql-pdb', $pdb1->getName());
         $this->assertEquals(['matchLabels' => ['tier' => 'backend']], $pdb1->getSelectors());
         $this->assertEquals(['tier' => 'backend'], $pdb1->getLabels());
@@ -41,7 +41,7 @@ class PodDisruptionBudgetTest extends TestCase
         $this->assertEquals('25%', $pdb1->getMaxUnavailable());
         $this->assertEquals(null, $pdb1->getMinAvailable());
 
-        $this->assertEquals('policy/v1beta1', $pdb2->getApiVersion());
+        $this->assertEquals('policy/v1', $pdb2->getApiVersion());
         $this->assertEquals('mysql-pdb', $pdb2->getName());
         $this->assertEquals(['matchLabels' => ['tier' => 'backend']], $pdb2->getSelectors());
         $this->assertEquals(['tier' => 'backend'], $pdb2->getLabels());
@@ -107,7 +107,7 @@ class PodDisruptionBudgetTest extends TestCase
         $this->assertInstanceOf(K8sDeployment::class, $dep);
         $this->assertInstanceOf(K8sPodDisruptionBudget::class, $pdb);
 
-        $this->assertEquals('policy/v1beta1', $pdb->getApiVersion());
+        $this->assertEquals('policy/v1', $pdb->getApiVersion());
         $this->assertEquals('mysql-pdb', $pdb->getName());
         $this->assertEquals(['matchLabels' => ['tier' => 'backend']], $pdb->getSelectors());
         $this->assertEquals(['tier' => 'backend'], $pdb->getLabels());
@@ -142,7 +142,7 @@ class PodDisruptionBudgetTest extends TestCase
 
         $this->assertTrue($pdb->isSynced());
 
-        $this->assertEquals('policy/v1beta1', $pdb->getApiVersion());
+        $this->assertEquals('policy/v1', $pdb->getApiVersion());
         $this->assertEquals('mysql-pdb', $pdb->getName());
         $this->assertEquals(['matchLabels' => ['tier' => 'backend']], $pdb->getSelectors());
         $this->assertEquals(['tier' => 'backend'], $pdb->getLabels());
@@ -163,7 +163,7 @@ class PodDisruptionBudgetTest extends TestCase
 
         $this->assertTrue($pdb->isSynced());
 
-        $this->assertEquals('policy/v1beta1', $pdb->getApiVersion());
+        $this->assertEquals('policy/v1', $pdb->getApiVersion());
         $this->assertEquals('mysql-pdb', $pdb->getName());
         $this->assertEquals(['matchLabels' => ['tier' => 'backend']], $pdb->getSelectors());
         $this->assertEquals(['tier' => 'backend'], $pdb->getLabels());

--- a/tests/PodTest.php
+++ b/tests/PodTest.php
@@ -127,14 +127,10 @@ class PodTest extends TestCase
         }
 
         $messages = $pod->exec(['/bin/sh', '-c', 'echo 1 && echo 2 && echo 3'], 'busybox-exec');
-
-        $hasDesiredOutput = collect($messages)->where('channel', 'stdout')->filter(function ($message) {
-            return Str::contains($message['output'], '1')
-                && Str::contains($message['output'], '2')
-                && Str::contains($message['output'], '3');
-        })->isNotEmpty();
-
-        $this->assertTrue($hasDesiredOutput);
+        $desiredOutput = collect($messages)->where('channel', 'stdout')->reduce(function(?string $carry, array $message) {
+           return $carry .= preg_replace('/\s+/', '', $message['output']);
+        });
+        $this->assertEquals("123", $desiredOutput);
 
         $pod->delete();
     }

--- a/tests/PodTest.php
+++ b/tests/PodTest.php
@@ -127,10 +127,10 @@ class PodTest extends TestCase
         }
 
         $messages = $pod->exec(['/bin/sh', '-c', 'echo 1 && echo 2 && echo 3'], 'busybox-exec');
-        $desiredOutput = collect($messages)->where('channel', 'stdout')->reduce(function(?string $carry, array $message) {
-           return $carry .= preg_replace('/\s+/', '', $message['output']);
+        $desiredOutput = collect($messages)->where('channel', 'stdout')->reduce(function (?string $carry, array $message) {
+            return $carry .= preg_replace('/\s+/', '', $message['output']);
         });
-        $this->assertEquals("123", $desiredOutput);
+        $this->assertEquals('123', $desiredOutput);
 
         $pod->delete();
     }

--- a/tests/PodTest.php
+++ b/tests/PodTest.php
@@ -15,7 +15,7 @@ class PodTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])
@@ -24,7 +24,7 @@ class PodTest extends TestCase
 
         $busybox = K8s::container()
             ->setName('busybox')
-            ->setImage('busybox')
+            ->setImage('public.ecr.aws/docker/library/busybox')
             ->setCommand(['/bin/sh']);
 
         $pod = $this->cluster->pod()
@@ -65,7 +65,7 @@ class PodTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])
@@ -74,7 +74,7 @@ class PodTest extends TestCase
 
         $busybox = K8s::container()
             ->setName('busybox')
-            ->setImage('busybox')
+            ->setImage('public.ecr.aws/docker/library/busybox')
             ->setCommand(['/bin/sh']);
 
         $pod = $this->cluster->fromYamlFile(__DIR__.'/yaml/pod.yaml');
@@ -112,7 +112,7 @@ class PodTest extends TestCase
     {
         $busybox = K8s::container()
             ->setName('busybox-exec')
-            ->setImage('busybox')
+            ->setImage('public.ecr.aws/docker/library/busybox')
             ->setCommand(['/bin/sh', '-c', 'sleep 7200']);
 
         $pod = $this->cluster->pod()
@@ -143,7 +143,7 @@ class PodTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql-attach')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])
@@ -174,7 +174,7 @@ class PodTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])
@@ -183,7 +183,7 @@ class PodTest extends TestCase
 
         $busybox = K8s::container()
             ->setName('busybox')
-            ->setImage('busybox')
+            ->setImage('public.ecr.aws/docker/library/busybox')
             ->setCommand(['/bin/sh']);
 
         $pod = $this->cluster->pod()

--- a/tests/PodTest.php
+++ b/tests/PodTest.php
@@ -217,8 +217,8 @@ class PodTest extends TestCase
 
         $pod->refresh();
 
-        $this->assertEquals('busybox:latest', $pod->getInitContainer('busybox')->getImage());
-        $this->assertEquals('mysql:5.7', $pod->getContainer('mysql')->getImage());
+        $this->assertStringEndsWith('busybox:latest', $pod->getInitContainer('busybox')->getImage());
+        $this->assertStringEndsWith('mysql:5.7', $pod->getContainer('mysql')->getImage());
 
         $this->assertTrue($pod->containersAreReady());
         $this->assertTrue($pod->initContainersAreReady());

--- a/tests/StatefulSetTest.php
+++ b/tests/StatefulSetTest.php
@@ -15,7 +15,7 @@ class StatefulSetTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ]);
@@ -65,7 +65,7 @@ class StatefulSetTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ]);
@@ -120,7 +120,7 @@ class StatefulSetTest extends TestCase
     {
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->setPorts([
                 ['name' => 'mysql', 'protocol' => 'TCP', 'containerPort' => 3306],
             ])

--- a/tests/VolumeTest.php
+++ b/tests/VolumeTest.php
@@ -15,7 +15,7 @@ class VolumeTest extends TestCase
 
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->addMountedVolumes([$mountedVolume])
             ->setMountedVolumes([$mountedVolume]);
 
@@ -54,7 +54,7 @@ class VolumeTest extends TestCase
 
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->addMountedVolumes([$mountedVolume]);
 
         $pod = K8s::pod()
@@ -92,7 +92,7 @@ class VolumeTest extends TestCase
 
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->addMountedVolumes([$mountedVolume]);
 
         $pod = K8s::pod()
@@ -123,7 +123,7 @@ class VolumeTest extends TestCase
 
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->addMountedVolumes([$mountedVolume]);
 
         $pod = K8s::pod()
@@ -156,7 +156,7 @@ class VolumeTest extends TestCase
 
         $mysql = K8s::container()
             ->setName('mysql')
-            ->setImage('mysql', '5.7')
+            ->setImage('public.ecr.aws/docker/library/mysql', '5.7')
             ->addMountedVolumes([$mountedVolume]);
 
         $pod = K8s::pod()

--- a/tests/yaml/cronjob.yaml
+++ b/tests/yaml/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
             - name: pi
-              image: perl:latest
+              image: public.ecr.aws/docker/library/perl:latest
               command:
                 - perl
                 - Mbignum=bpi

--- a/tests/yaml/cronjob.yaml
+++ b/tests/yaml/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: pi
@@ -12,8 +12,6 @@ spec:
     spec:
       ttlSecondsAfterFinished: 3600
       template:
-        apiVersion: batch/v1
-        kind: Job
         metadata:
           name: pi
           labels:
@@ -29,7 +27,3 @@ spec:
                 - Mbignum=bpi
                 - -wle
                 - print bpi(2000)
-          kind: Pod
-          apiVersion: v1
-    apiVersion: batch/v1
-    kind: Job

--- a/tests/yaml/cronjob.yaml
+++ b/tests/yaml/cronjob.yaml
@@ -26,4 +26,4 @@ spec:
                 - perl
                 - Mbignum=bpi
                 - -wle
-                - print bpi(2000)
+                - print bpi(200)

--- a/tests/yaml/daemonset.yaml
+++ b/tests/yaml/daemonset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: mysql:5.7
+          image: public.ecr.aws/docker/library/mysql:5.7
           ports:
             - name: mysql
               protocol: TCP

--- a/tests/yaml/daemonset.yaml
+++ b/tests/yaml/daemonset.yaml
@@ -5,9 +5,14 @@ metadata:
   labels:
     tier: backend
 spec:
+  selector:
+    matchLabels:
+      name: mysql-daemonset
   template:
     metadata:
       name: mysql
+      labels:
+        name: mysql-daemonset
     spec:
       containers:
         - name: mysql
@@ -15,6 +20,3 @@ spec:
           ports:
             - name: mysql
               protocol: TCP
-              containerPort: 3306
-    kind: Pod
-    apiVersion: v1

--- a/tests/yaml/deployment.yaml
+++ b/tests/yaml/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: mysql:5.7
+          image: public.ecr.aws/docker/library/mysql:5.7
           ports:
             - name: mysql
               protocol: TCP

--- a/tests/yaml/deployment.yaml
+++ b/tests/yaml/deployment.yaml
@@ -7,10 +7,15 @@ metadata:
   annotations:
     mysql/annotation: "yes"
 spec:
+  selector:
+    matchLabels:
+      name: mysql-deployment
   replicas: 3
   template:
     metadata:
       name: mysql
+      labels:
+        name: mysql-deployment
     spec:
       containers:
         - name: mysql
@@ -19,5 +24,3 @@ spec:
             - name: mysql
               protocol: TCP
               containerPort: 3306
-    kind: Pod
-    apiVersion: v1

--- a/tests/yaml/hpa.yaml
+++ b/tests/yaml/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: mysql-hpa

--- a/tests/yaml/job.yaml
+++ b/tests/yaml/job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: pi
   labels:
-    tier: backend
+    tier: compute
   annotations:
     perl/annotation: "yes"
 spec:

--- a/tests/yaml/job.yaml
+++ b/tests/yaml/job.yaml
@@ -20,5 +20,3 @@ spec:
             - Mbignum=bpi
             - -wle
             - print bpi(2000)
-    kind: Pod
-    apiVersion: v1

--- a/tests/yaml/job.yaml
+++ b/tests/yaml/job.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: pi
-          image: perl:latest
+          image: public.ecr.aws/docker/library/perl:latest
           command:
             - perl
             - Mbignum=bpi

--- a/tests/yaml/job.yaml
+++ b/tests/yaml/job.yaml
@@ -19,4 +19,4 @@ spec:
             - perl
             - Mbignum=bpi
             - -wle
-            - print bpi(2000)
+            - print bpi(200)

--- a/tests/yaml/pdb.yaml
+++ b/tests/yaml/pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: mysql-pdb
@@ -12,7 +12,7 @@ spec:
       tier: backend
   maxUnavailable: 25%
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: mysql-pdb

--- a/tests/yaml/pod.yaml
+++ b/tests/yaml/pod.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   initContainers:
     - name: busybox
-      image: busybox:latest
+      image: public.ecr.aws/docker/library/busybox:latest
       command:
         - /bin/sh
   containers:
     - name: mysql
-      image: mysql:5.7
+      image: public.ecr.aws/docker/library/mysql:5.7
       ports:
         - name: mysql
           protocol: TCP

--- a/tests/yaml/statefulset.yaml
+++ b/tests/yaml/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: mysql:5.7
+          image: public.ecr.aws/docker/library/mysql:5.7
           ports:
             - name: mysql
               protocol: TCP

--- a/tests/yaml/statefulset.yaml
+++ b/tests/yaml/statefulset.yaml
@@ -7,11 +7,16 @@ metadata:
   annotations:
     mysql/annotation: "yes"
 spec:
+  selector:
+    matchLabels:
+      name: mysql-statefulset
   replicas: 3
   serviceName: mysql
   template:
     metadata:
       name: mysql
+      labels:
+        name: mysql-statefulset
     spec:
       containers:
         - name: mysql


### PR DESCRIPTION
Attempting to resolve issues with Laravel 10 support. Bumping various versions in the package.

This PR updates the following things:

1. Kubernetes version 1.22 removed, 1.25 added 
2. Kubernetes 1.23->1.25 bumped to current minor versions
3. Add Laravel 10
4. Add PHP 8.2 to the testing matrix (Laravel 10 only)
5. Fixes a couple small issues with some tests (optional kube features, image/registry expansion)
6. Update PodDisruptionBudget default and tests to v1 (from v1beta1)
7. Update HorizontalPodAutoscaler default and tests to v2 (from v2beta2)
8. Update CronJob default and tests to v1 (from v1beta1)

Resolves #324