### PR TITLE
Add feature for Taints on Nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,14 @@ jobs:
         path: ~/.composer/cache/files
         key: composer-php-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.prefer }}-${{ hashFiles('composer.json') }}
 
-    - uses: manusa/actions-setup-minikube@v2.6.1
+    - uses: manusa/actions-setup-minikube@v2.7.0
       name: Setup Minikube
       with:
         minikube version: v1.25.2
         kubernetes version: "v${{ matrix.kubernetes }}"
         github token: "${{ secrets.GITHUB_TOKEN }}"
+        driver: docker
+
 
     - name: Run Kubernetes Proxy
       run: |
@@ -79,7 +81,7 @@ jobs:
 
     - name: Setting CRDs for testing
       run: |
-        kubectl apply -f https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/main/helm/sealed-secrets/crds/sealedsecret-crd.yaml
+        kubectl apply -f https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/main/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
 
     # - name: Run static analysis
     #   run: |

--- a/src/Exceptions/KubernetesInvalidTaintEffect.php
+++ b/src/Exceptions/KubernetesInvalidTaintEffect.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Exceptions;
+
+class KubernetesInvalidTaintEffect extends PhpK8sException
+{
+    //
+}

--- a/src/Instances/Taint.php
+++ b/src/Instances/Taint.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Instances;
+
+use RenokiCo\PhpK8s\Exceptions\KubernetesInvalidTaintEffect;
+
+class Taint extends Instance
+{
+    const EFFECTS = [
+        self::EFFECT_NO_SCHEDULE,
+        self::EFFECT_PREFER_NO_SCHEDULE,
+        self::EFFECT_NO_EXECUTE,
+    ];
+
+    public const EFFECT_NO_SCHEDULE = 'NoSchedule';
+    public const EFFECT_PREFER_NO_SCHEDULE = 'PreferNoSchedule';
+    public const EFFECT_NO_EXECUTE = 'NoExecute';
+
+    /**
+     * Set the value of a taint.
+     *
+     * @param  string|bool|int  $value
+     */
+    public function setValue($value)
+    {
+        if (gettype($value) === 'boolean') {
+            $value = $value ? 'true' : 'false';
+        }
+
+        return $this->setAttribute('value', (string) $value);
+    }
+
+    /**
+     * Set the effect of a taint.
+     *
+     * @param  string  $effect
+     *
+     * @throws KubernetesInvalidTaintEffect
+     */
+    public function setEffect(string $effect)
+    {
+        if (! in_array($effect, self::EFFECTS)) {
+            throw new KubernetesInvalidTaintEffect("'{$effect}' is not a valid Taint effect.");
+        }
+
+        return $this->setAttribute('effect', $effect);
+    }
+
+    /**
+     * Set the key of a taint.
+     *
+     * @param  string  $key
+     */
+    public function setKey(string $key)
+    {
+        return $this->setAttribute('key', $key);
+    }
+}

--- a/src/Kinds/K8sNode.php
+++ b/src/Kinds/K8sNode.php
@@ -5,10 +5,12 @@ namespace RenokiCo\PhpK8s\Kinds;
 use RenokiCo\PhpK8s\Contracts\InteractsWithK8sCluster;
 use RenokiCo\PhpK8s\Contracts\Watchable;
 use RenokiCo\PhpK8s\Traits\Resource\HasStatus;
+use RenokiCo\PhpK8s\Traits\Resource\HasTaints;
 
 class K8sNode extends K8sResource implements InteractsWithK8sCluster, Watchable
 {
     use HasStatus;
+    use HasTaints;
 
     /**
      * The resource Kind parameter.

--- a/src/Kinds/K8sResource.php
+++ b/src/Kinds/K8sResource.php
@@ -176,6 +176,7 @@ class K8sResource implements Arrayable, Jsonable
         $attributes = str_replace('"allowedTopologies": {}', '"allowedTopologies": []', $attributes);
         $attributes = str_replace('"mountOptions": {}', '"mountOptions": []', $attributes);
         $attributes = str_replace('"accessModes": {}', '"accessModes": []', $attributes);
+        $attributes = str_replace('"taints": {}', '"taints": []', $attributes);
 
         return $attributes;
     }

--- a/src/Traits/InitializesInstances.php
+++ b/src/Traits/InitializesInstances.php
@@ -10,6 +10,7 @@ use RenokiCo\PhpK8s\Instances\ResourceMetric;
 use RenokiCo\PhpK8s\Instances\ResourceObject;
 use RenokiCo\PhpK8s\Instances\Rule;
 use RenokiCo\PhpK8s\Instances\Subject;
+use RenokiCo\PhpK8s\Instances\Taint;
 use RenokiCo\PhpK8s\Instances\Volume;
 use RenokiCo\PhpK8s\Instances\Webhook;
 
@@ -123,5 +124,16 @@ trait InitializesInstances
     public static function webhook(array $attributes = [])
     {
         return new Webhook($attributes);
+    }
+
+    /**
+     * Create a new Taint instance.
+     *
+     * @param  array  $attributes
+     * @return \RenokiCo\PhpK8s\Instances\Taint
+     */
+    public static function taint(array $attributes = [])
+    {
+        return new Taint($attributes);
     }
 }

--- a/src/Traits/Resource/HasTaints.php
+++ b/src/Traits/Resource/HasTaints.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Traits\Resource;
+
+use RenokiCo\PhpK8s\Instances\Taint;
+use RenokiCo\PhpK8s\K8s;
+
+trait HasTaints
+{
+    /**
+     * Get the taints from the resource.
+     *
+     * @param  bool  $asInstance
+     * @return array
+     */
+    public function getTaints(bool $asInstance = true): array
+    {
+        $taints = $this->getAttribute('spec.taints', []);
+
+        if ($asInstance) {
+            foreach ($taints as &$taint) {
+                $taint = K8s::taint($taint);
+            }
+        }
+
+        return $taints;
+    }
+
+    /**
+     * Add a new taint.
+     *
+     * @param  array|\RenokiCo\PhpK8s\Instances\  $taint
+     * @return $this
+     */
+    public function addTaint($taint)
+    {
+        if ($taint instanceof Taint) {
+            $taint = $taint->toArray();
+        }
+
+        return $this->addToAttribute('spec.taints', $taint);
+    }
+
+    /**
+     * Batch add multiple taints.
+     *
+     * @param  array  $taints
+     * @return $this
+     */
+    public function addTaints($taints)
+    {
+        foreach ($taints as $taint) {
+            $this->addTaint($taint);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the taints of the resource.
+     *
+     * @param  array  $taints
+     * @return $this
+     */
+    public function setTaints(array $taints)
+    {
+        foreach ($taints as &$taint) {
+            if ($taint instanceof Taint) {
+                $taint = $taint->toArray();
+            }
+        }
+
+        return $this->setAttribute('spec.taints', $taints);
+    }
+
+    /**
+     * Removes a taint from the resource.
+     *
+     * @param  array|\RenokiCo\PhpK8s\Instances\  $taint
+     * @return $this
+     */
+    public function removeTaint($taint)
+    {
+        if ($taint instanceof Taint) {
+            $taint = $taint->toArray();
+        }
+
+        $originalTaints = $this->getTaints(false);
+        foreach ($originalTaints as &$originalTaint) {
+            if ($taint['key'] === $originalTaint['key'] && $taint['effect'] === $originalTaint['effect']) {
+                unset($originalTaint);
+            }
+        }
+
+        return $this->setTaints($originalTaints);
+    }
+
+    /**
+     * Update a taint on the resource.
+     *
+     * @param  array|\RenokiCo\PhpK8s\Instances\  $taint
+     * @return $this
+     */
+    public function updateTaint($taint)
+    {
+        if ($taint instanceof Taint) {
+            $taint = $taint->toArray();
+        }
+
+        $originalTaints = $this->getTaints(false);
+        foreach ($originalTaints as &$originalTaint) {
+            if ($taint['key'] === $originalTaint['key'] && $taint['effect'] === $originalTaint['effect']) {
+                $originalTaint = $taint;
+            }
+        }
+
+        return $this->setTaints($originalTaints);
+    }
+}

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -43,6 +43,7 @@ class NodeTest extends TestCase
         $this->assertTrue(is_array($node->getImages()));
         $this->assertNotEquals([], $node->getCapacity());
         $this->assertNotEquals([], $node->getAllocatableInfo());
+        $this->assertEquals([], $node->getTaints());
     }
 
     public function runWatchAllTests()

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Test;
+
+use RenokiCo\PhpK8s\Exceptions\KubernetesInvalidTaintEffect;
+use RenokiCo\PhpK8s\Instances\Taint;
+use RenokiCo\PhpK8s\K8s;
+
+class TaintTest extends TestCase
+{
+    public function test_build_taint()
+    {
+        $taint = K8s::taint()
+            ->setKey('test')
+            ->setValue(true)
+            ->setEffect(Taint::EFFECT_NO_EXECUTE);
+
+        $this->assertEquals('test', $taint->getKey());
+        $this->assertEquals('true', $taint->getValue());
+        $this->assertEquals('NoExecute', $taint->getEffect());
+    }
+
+    public function test_build_taint_invalid_effect()
+    {
+        $this->expectException(KubernetesInvalidTaintEffect::class);
+        $this->expectExceptionMessage("'test' is not a valid Taint effect.");
+
+        K8s::taint()
+            ->setKey('test')
+            ->setValue(true)
+            ->setEffect('test');
+    }
+}


### PR DESCRIPTION
* This feature adds support for adding, updating and removing [taints](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) from a Node
* Some of the workflows have been updated to pass with the latest Ubuntu image