### PR TITLE
Fix log retrieval when pod output is JSON parseable

### DIFF
--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -201,9 +201,13 @@ class KubernetesCluster
      */
     public function runOperation(string $operation, string $path, $payload = '', array $query = ['pretty' => 1])
     {
+        /** @var bool Force makeRequest to return raw data instead of parsing JSON/object */
+        $return_raw = false;
+
         switch ($operation) {
             case static::WATCH_OP: return $this->watchPath($path, $payload, $query); break;
             case static::WATCH_LOGS_OP: return $this->watchLogsPath($path, $payload, $query); break;
+            case static::LOG_OP: $return_raw = true; break;
             case static::EXEC_OP: return $this->execPath($path, $query); break;
             case static::ATTACH_OP: return $this->attachPath($path, $payload, $query); break;
             default: break;
@@ -211,7 +215,7 @@ class KubernetesCluster
 
         $method = static::$operations[$operation] ?? static::$operations[static::GET_OP];
 
-        return $this->makeRequest($method, $path, $payload, $query);
+        return $this->makeRequest($method, $path, $payload, $query, $return_raw);
     }
 
     /**

--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -202,12 +202,12 @@ class KubernetesCluster
     public function runOperation(string $operation, string $path, $payload = '', array $query = ['pretty' => 1])
     {
         /** @var bool Force makeRequest to return raw data instead of parsing JSON/object */
-        $return_raw = false;
+        $returnRaw = false;
 
         switch ($operation) {
             case static::WATCH_OP: return $this->watchPath($path, $payload, $query); break;
             case static::WATCH_LOGS_OP: return $this->watchLogsPath($path, $payload, $query); break;
-            case static::LOG_OP: $return_raw = true; break;
+            case static::LOG_OP: $returnRaw = true; break;
             case static::EXEC_OP: return $this->execPath($path, $query); break;
             case static::ATTACH_OP: return $this->attachPath($path, $payload, $query); break;
             default: break;
@@ -215,7 +215,7 @@ class KubernetesCluster
 
         $method = static::$operations[$operation] ?? static::$operations[static::GET_OP];
 
-        return $this->makeRequest($method, $path, $payload, $query, $return_raw);
+        return $this->makeRequest($method, $path, $payload, $query, $returnRaw);
     }
 
     /**

--- a/src/Traits/Cluster/MakesHttpCalls.php
+++ b/src/Traits/Cluster/MakesHttpCalls.php
@@ -103,15 +103,20 @@ trait MakesHttpCalls
      * @param  string  $path
      * @param  string  $payload
      * @param  array  $query
+     * @param  array  $return_raw skip JSON parse and return raw data
      * @return mixed
      *
      * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
      */
-    protected function makeRequest(string $method, string $path, string $payload = '', array $query = ['pretty' => 1])
+    protected function makeRequest(string $method, string $path, string $payload = '', array $query = ['pretty' => 1], $return_raw = false)
     {
         $resourceClass = $this->resourceClass;
 
         $response = $this->call($method, $path, $payload, $query);
+
+        if ($return_raw) {
+            return (string) $response->getBody();
+        }
 
         $json = @json_decode($response->getBody(), true);
 

--- a/src/Traits/Cluster/MakesHttpCalls.php
+++ b/src/Traits/Cluster/MakesHttpCalls.php
@@ -103,18 +103,23 @@ trait MakesHttpCalls
      * @param  string  $path
      * @param  string  $payload
      * @param  array  $query
-     * @param  array  $return_raw skip JSON parse and return raw data
+     * @param  array  $returnRaw  skip JSON parse and return raw data
      * @return mixed
      *
      * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
      */
-    protected function makeRequest(string $method, string $path, string $payload = '', array $query = ['pretty' => 1], $return_raw = false)
-    {
+    protected function makeRequest(
+        string $method,
+        string $path,
+        string $payload = '',
+        array $query = ['pretty' => 1],
+        $returnRaw = false
+    ) {
         $resourceClass = $this->resourceClass;
 
         $response = $this->call($method, $path, $payload, $query);
 
-        if ($return_raw) {
+        if ($returnRaw) {
             return (string) $response->getBody();
         }
 

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -154,6 +154,13 @@ class JobTest extends TestCase
             $job->refresh();
         }
 
+        foreach ($job->getPods() as $pod) {
+            $log = $pod->logs();
+            // Long string so it fails if any stage wasn't parsed as string
+            $pi = '3.14159265358979323846264338327950288419716939937510582097494459230781640628620';
+            $this->assertStringStartsWith($pi, $log);
+        }
+
         $this->assertTrue($job->getDurationInSeconds() > 0);
         $this->assertEquals(0, $job->getActivePodsCount());
         $this->assertEquals(0, $job->getFailedPodsCount());


### PR DESCRIPTION
The output for the pi pod is json parseable, and when calling `→logs()` it causes the following error:

```
TypeError: RenokiCo\PhpK8s\Kinds\K8sResource::__construct(): Argument #2 
($attributes) must be of type array, float given, 
called in /.../src/Traits/Cluster/MakesHttpCalls.php on line 143
```

To reproduce:

- Execute any job (or deployment) with PI (or any other container) that outputs JSON-friendly data
- Select the K8sPod instance, Call `→logs()`
Check https://github.com/renoki-co/php-k8s/commit/68cc3aef204720369eed67fdc20e512630e50bed for a reproducible test.

The output is often non-parseable, but a well-forged output could cause a sort of “injection” at the Resource class attributes. Leading to errors or unexpected behaviour. 

The log output should always return in string format.

Tested on Minikube using 1.26.3 and k3s using 1.25.6.