### PR TITLE
Replace deprecated package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/main/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
 
       - name: Run tests
+        env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes }}
         run: |
           vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,13 @@
         }
     ],
     "require": {
+        "ext-json": "*",
+        "composer/semver": "^2.0|^3.0",
         "guzzlehttp/guzzle": "^6.5|^7.0",
         "illuminate/macroable": "^9.35|^10.1|^11.0",
         "illuminate/support": "^9.35|^10.1|^11.0",
         "ratchet/pawl": "^0.4.1",
-        "symfony/process": "^5.4|^6.0|^7.0",
-        "vierbergenlars/php-semver": "^2.1|^3.0"
+        "symfony/process": "^5.4|^6.0|^7.0"
     },
     "suggest": {
         "ext-yaml": "YAML extension is used to read or generate YAML from PHP K8s internal classes."

--- a/tests/CheckClusterVersionTest.php
+++ b/tests/CheckClusterVersionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Test;
+
+class CheckClusterVersionTest extends TestCase
+{
+    protected $clusterVersion;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->clusterVersion = $_SERVER['KUBERNETES_VERSION'];
+    }
+
+    public function test_newer_than()
+    {
+        $this->assertTrue($this->cluster->newerThan($this->clusterVersion));
+        $this->assertTrue($this->cluster->newerThan('v'.$this->clusterVersion));
+        $this->assertTrue($this->cluster->newerThan($this->change_version(1, 0)));
+        $this->assertFalse($this->cluster->newerThan($this->change_version(2, 99)));
+    }
+
+    public function test_old_than()
+    {
+        $this->assertFalse($this->cluster->olderThan($this->clusterVersion));
+        $this->assertFalse($this->cluster->olderThan('v'.$this->clusterVersion));
+        $this->assertTrue($this->cluster->olderThan($this->change_version(1, 99)));
+        $this->assertTrue($this->cluster->olderThan($this->change_version(0, 2)));
+        $this->assertFalse($this->cluster->olderThan($this->change_version(1, 0)));
+    }
+
+    protected function change_version(int $position, int $version): string
+    {
+        $parts = explode('.', $this->clusterVersion);
+        $parts[$position] = $version;
+
+        return implode('.', $parts);
+    }
+}


### PR DESCRIPTION
[vierbergenlars/php-semver](https://github.com/vierbergenlars/php-semver) has been deprecated and can be replaced by composer/semver.

Also add the missing json ext requirement.