### PR TITLE
Adds patch support

### DIFF
--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -208,13 +208,26 @@ class KubernetesCluster
     public function runOperation(string $operation, string $path, $payload = '', array $query = ['pretty' => 1], array $options = [])
     {
         switch ($operation) {
-            case static::WATCH_OP: return $this->watchPath($path, $payload, $query); break;
-            case static::WATCH_LOGS_OP: return $this->watchLogsPath($path, $payload, $query); break;
-            case static::EXEC_OP: return $this->execPath($path, $query); break;
-            case static::ATTACH_OP: return $this->attachPath($path, $payload, $query); break;
-            case static::MERGE_PATCH_OP: $options[RequestOptions::HEADERS]["Content-Type"] = "application/merge-patch+json"; break;
-            case static::JSON_PATCH_OP: $options[RequestOptions::HEADERS]["Content-Type"] = "application/json-patch+json"; break;
-            default: break;
+            case static::WATCH_OP:
+                return $this->watchPath($path, $payload, $query);
+                break;
+            case static::WATCH_LOGS_OP:
+                return $this->watchLogsPath($path, $payload, $query);
+                break;
+            case static::EXEC_OP:
+                return $this->execPath($path, $query);
+                break;
+            case static::ATTACH_OP:
+                return $this->attachPath($path, $payload, $query);
+                break;
+            case static::MERGE_PATCH_OP:
+                $options[RequestOptions::HEADERS]["Content-Type"] = "application/merge-patch+json";
+                break;
+            case static::JSON_PATCH_OP:
+                $options[RequestOptions::HEADERS]["Content-Type"] = "application/json-patch+json";
+                break;
+            default:
+                break;
         }
 
         $method = static::$operations[$operation] ?? static::$operations[static::GET_OP];

--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -205,8 +205,13 @@ class KubernetesCluster
      *
      * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
      */
-    public function runOperation(string $operation, string $path, $payload = '', array $query = ['pretty' => 1], array $options = [])
-    {
+    public function runOperation(
+        string $operation,
+        string $path,
+               $payload = '',
+        array  $query = ['pretty' => 1],
+        array  $options = []
+    ): mixed {
         switch ($operation) {
             case static::WATCH_OP:
                 return $this->watchPath($path, $payload, $query);

--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -208,9 +208,9 @@ class KubernetesCluster
     public function runOperation(
         string $operation,
         string $path,
-               $payload = '',
-        array  $query = ['pretty' => 1],
-        array  $options = []
+        string $payload = '',
+        array $query = ['pretty' => 1],
+        array $options = []
     ): mixed {
         switch ($operation) {
             case static::WATCH_OP:
@@ -226,10 +226,10 @@ class KubernetesCluster
                 return $this->attachPath($path, $payload, $query);
                 break;
             case static::MERGE_PATCH_OP:
-                $options[RequestOptions::HEADERS]["Content-Type"] = "application/merge-patch+json";
+                $options[RequestOptions::HEADERS]["Content-Type"] = 'application/merge-patch+json';
                 break;
             case static::JSON_PATCH_OP:
-                $options[RequestOptions::HEADERS]["Content-Type"] = "application/json-patch+json";
+                $options[RequestOptions::HEADERS]["Content-Type"] = 'application/json-patch+json';
                 break;
             default:
                 break;

--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -226,10 +226,10 @@ class KubernetesCluster
                 return $this->attachPath($path, $payload, $query);
                 break;
             case static::MERGE_PATCH_OP:
-                $options[RequestOptions::HEADERS]["Content-Type"] = 'application/merge-patch+json';
+                $options[RequestOptions::HEADERS]['Content-Type'] = 'application/merge-patch+json';
                 break;
             case static::JSON_PATCH_OP:
-                $options[RequestOptions::HEADERS]["Content-Type"] = 'application/json-patch+json';
+                $options[RequestOptions::HEADERS]['Content-Type'] = 'application/json-patch+json';
                 break;
             default:
                 break;

--- a/src/Traits/Cluster/MakesHttpCalls.php
+++ b/src/Traits/Cluster/MakesHttpCalls.php
@@ -84,7 +84,6 @@ trait MakesHttpCalls
         array $query = ['pretty' => 1],
         array $options = []
     ): \Psr\Http\Message\ResponseInterface {
-
         if ($payload) {
             $options[RequestOptions::BODY] = $payload;
         }

--- a/src/Traits/Cluster/MakesHttpCalls.php
+++ b/src/Traits/Cluster/MakesHttpCalls.php
@@ -77,12 +77,20 @@ trait MakesHttpCalls
      *
      * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
      */
-    public function call(string $method, string $path, string $payload = '', array $query = ['pretty' => 1])
-    {
+    public function call(
+        string $method,
+        string $path,
+        string $payload = '',
+        array  $query = ['pretty' => 1],
+        array  $options = []
+    ): \Psr\Http\Message\ResponseInterface {
+
+        if ($payload) {
+            $options[RequestOptions::BODY] = $payload;
+        }
+
         try {
-            $response = $this->getClient()->request($method, $this->getCallableUrl($path, $query), [
-                RequestOptions::BODY => $payload,
-            ]);
+            $response = $this->getClient()->request($method, $this->getCallableUrl($path, $query), $options);
         } catch (ClientException $e) {
             $errorPayload = json_decode((string) $e->getResponse()->getBody(), true);
 
@@ -103,15 +111,21 @@ trait MakesHttpCalls
      * @param  string  $path
      * @param  string  $payload
      * @param  array  $query
+     * @param  array  $options
      * @return mixed
      *
      * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
      */
-    protected function makeRequest(string $method, string $path, string $payload = '', array $query = ['pretty' => 1])
-    {
+    protected function makeRequest(
+        string $method,
+        string $path,
+        string $payload = '',
+        array  $query = ['pretty' => 1],
+        array  $options = []
+    ): mixed {
         $resourceClass = $this->resourceClass;
 
-        $response = $this->call($method, $path, $payload, $query);
+        $response = $this->call($method, $path, $payload, $query, $options);
 
         $json = @json_decode($response->getBody(), true);
 

--- a/src/Traits/Cluster/MakesHttpCalls.php
+++ b/src/Traits/Cluster/MakesHttpCalls.php
@@ -81,8 +81,8 @@ trait MakesHttpCalls
         string $method,
         string $path,
         string $payload = '',
-        array  $query = ['pretty' => 1],
-        array  $options = []
+        array $query = ['pretty' => 1],
+        array $options = []
     ): \Psr\Http\Message\ResponseInterface {
 
         if ($payload) {
@@ -120,8 +120,8 @@ trait MakesHttpCalls
         string $method,
         string $path,
         string $payload = '',
-        array  $query = ['pretty' => 1],
-        array  $options = []
+        array $query = ['pretty' => 1],
+        array $options = []
     ): mixed {
         $resourceClass = $this->resourceClass;
 

--- a/src/Traits/RunsClusterOperations.php
+++ b/src/Traits/RunsClusterOperations.php
@@ -256,9 +256,9 @@ trait RunsClusterOperations
     }
 
     /**
-     * Issue a patch operation towards a cluster
+     * Issue a patch operation towards a cluster.
      *
-     * @param  array $payload JSON
+     * @param  array  $payload JSON
      * @param  array  $query
      * @return bool
      *
@@ -282,11 +282,11 @@ trait RunsClusterOperations
         return true;
     }
 
-    public function pachJSONType(string $op, string $path, ?string $value = null, array $query = ['pretty' => 1]): bool
+    public function patchJSONType(string $op, string $path, ?string $value = null, array $query = ['pretty' => 1]): bool
     {
         $this->refreshResourceVersion();
 
-        $payload = [["op" => $op, "path" => $path, "value" => $value]];
+        $payload = [['op' => $op, 'path' => $path, 'value' => $value]];
 
         $instance = $this->cluster
             ->setResourceClass(get_class($this))
@@ -492,7 +492,7 @@ trait RunsClusterOperations
     /**
      * Exec a command on the current resource.
      *
-     * @param array|string $command
+     * @param array|string  $command
      * @param  string|null  $container
      * @param  array  $query
      * @return string
@@ -502,8 +502,8 @@ trait RunsClusterOperations
      */
     public function exec(
         array|string $command,
-        string       $container = null,
-        array        $query = ['pretty' => 1, 'stdin' => 1, 'stdout' => 1, 'stderr' => 1, 'tty' => 1]
+        string $container = null,
+        array $query = ['pretty' => 1, 'stdin' => 1, 'stdout' => 1, 'stderr' => 1, 'tty' => 1]
     ) {
         if (! $this instanceof Executable) {
             throw new KubernetesExecException(

--- a/src/Traits/RunsClusterOperations.php
+++ b/src/Traits/RunsClusterOperations.php
@@ -282,11 +282,11 @@ trait RunsClusterOperations
         return true;
     }
 
-    public function patchJSONType(string $op, string $path, ?string $value = null, array $query = ['pretty' => 1]): bool
+    public function patchJSONType(string $operation, string $path, ?string $value = null, array $query = ['pretty' => 1]): bool
     {
         $this->refreshResourceVersion();
 
-        $payload = [['op' => $op, 'path' => $path, 'value' => $value]];
+        $payload = [['op' => $operation, 'path' => $path, 'value' => $value]];
 
         $instance = $this->cluster
             ->setResourceClass(get_class($this))

--- a/src/Traits/RunsClusterOperations.php
+++ b/src/Traits/RunsClusterOperations.php
@@ -256,6 +256,53 @@ trait RunsClusterOperations
     }
 
     /**
+     * Issue a patch operation towards a cluster
+     *
+     * @param  array $payload JSON
+     * @param  array  $query
+     * @return bool
+     *
+     * @throws KubernetesAPIException
+     **/
+    public function patchMergeType(array $payload, array $query = ['pretty' => 1]): bool
+    {
+        $this->refreshResourceVersion();
+
+        $instance = $this->cluster
+            ->setResourceClass(get_class($this))
+            ->runOperation(
+                KubernetesCluster::MERGE_PATCH_OP,
+                $this->resourcePath(),
+                json_encode($payload),
+                $query
+            );
+
+        $this->syncWith($instance->toArray());
+
+        return true;
+    }
+
+    public function pachJSONType(string $op, string $path, ?string $value = null, array $query = ['pretty' => 1]): bool
+    {
+        $this->refreshResourceVersion();
+
+        $payload = [["op" => $op, "path" => $path, "value" => $value]];
+
+        $instance = $this->cluster
+            ->setResourceClass(get_class($this))
+            ->runOperation(
+                KubernetesCluster::JSON_PATCH_OP,
+                $this->resourcePath(),
+                json_encode($payload),
+                $query
+            );
+
+        $this->syncWith($instance->toArray());
+
+        return true;
+    }
+
+    /**
      * Delete the resource.
      *
      * @param  array  $query
@@ -445,7 +492,7 @@ trait RunsClusterOperations
     /**
      * Exec a command on the current resource.
      *
-     * @param  string|array  $command
+     * @param array|string $command
      * @param  string|null  $container
      * @param  array  $query
      * @return string
@@ -454,9 +501,9 @@ trait RunsClusterOperations
      * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
      */
     public function exec(
-        $command,
-        string $container = null,
-        array $query = ['pretty' => 1, 'stdin' => 1, 'stdout' => 1, 'stderr' => 1, 'tty' => 1]
+        array|string $command,
+        string       $container = null,
+        array        $query = ['pretty' => 1, 'stdin' => 1, 'stdout' => 1, 'stderr' => 1, 'tty' => 1]
     ) {
         if (! $this instanceof Executable) {
             throw new KubernetesExecException(

--- a/src/Traits/RunsClusterOperations.php
+++ b/src/Traits/RunsClusterOperations.php
@@ -258,7 +258,7 @@ trait RunsClusterOperations
     /**
      * Issue a patch operation towards a cluster.
      *
-     * @param  array  $payload JSON
+     * @param  array  $payload  JSON
      * @param  array  $query
      * @return bool
      *
@@ -282,8 +282,12 @@ trait RunsClusterOperations
         return true;
     }
 
-    public function patchJSONType(string $operation, string $path, ?string $value = null, array $query = ['pretty' => 1]): bool
-    {
+    public function patchJSONType(
+        string $operation,
+        string $path,
+        ?string $value = null,
+        array $query = ['pretty' => 1]
+    ): bool {
         $this->refreshResourceVersion();
 
         $payload = [['op' => $operation, 'path' => $path, 'value' => $value]];
@@ -492,7 +496,7 @@ trait RunsClusterOperations
     /**
      * Exec a command on the current resource.
      *
-     * @param array|string  $command
+     * @param  array|string  $command
      * @param  string|null  $container
      * @param  array  $query
      * @return string

--- a/tests/DeploymentTest.php
+++ b/tests/DeploymentTest.php
@@ -75,6 +75,7 @@ class DeploymentTest extends TestCase
         $this->runUpdateTests();
         $this->runWatchAllTests();
         $this->runWatchTests();
+        $this->runPatchTests();
         $this->runDeletionTests();
     }
 
@@ -237,6 +238,23 @@ class DeploymentTest extends TestCase
         $this->assertEquals(2, $dep->getReplicas());
 
         $this->assertInstanceOf(K8sPod::class, $dep->getTemplate());
+    }
+
+    /**
+     * @throws KubernetesAPIException
+     */
+    public function runPatchTests()
+    {
+        $dep = $this->cluster->getDeploymentByName('mysql');
+
+        $this->assertTrue($dep->isSynced());
+
+        $dep->patchMergeType(["metadata" => ["annotations" => ["foo" => "bar"]]]);
+        $dep->pachJSONType("add", "/metadata/annotations/foo2", "bar2");
+
+        $this->assertTrue($dep->isSynced());
+        $this->assertTrue(($dep->getAnnotations()["foo"] ?? false) == "bar");
+        $this->assertTrue(($dep->getAnnotations()["foo2"] ?? false) == "bar2");
     }
 
     public function runDeletionTests()

--- a/tests/DeploymentTest.php
+++ b/tests/DeploymentTest.php
@@ -249,12 +249,12 @@ class DeploymentTest extends TestCase
 
         $this->assertTrue($dep->isSynced());
 
-        $dep->patchMergeType(["metadata" => ["annotations" => ["foo" => "bar"]]]);
-        $dep->pachJSONType("add", "/metadata/annotations/foo2", "bar2");
+        $dep->patchMergeType(['metadata' => ['annotations' => ['foo' => 'bar']]]);
+        $dep->pachJSONType('add', '/metadata/annotations/foo2', 'bar2');
 
         $this->assertTrue($dep->isSynced());
-        $this->assertTrue(($dep->getAnnotations()["foo"] ?? false) == "bar");
-        $this->assertTrue(($dep->getAnnotations()["foo2"] ?? false) == "bar2");
+        $this->assertTrue(($dep->getAnnotations()['foo'] ?? false) == 'bar');
+        $this->assertTrue(($dep->getAnnotations()['foo2'] ?? false) == 'bar2');
     }
 
     public function runDeletionTests()


### PR DESCRIPTION
Supports JSON patch type and MERGE patch type.
For patching existing resources instead of syncing the entire manifest. Especially useful when parts of a resource might be immutable.