### PR TITLE
Multiple bumps & fixes to CI versions (Kubernetes, GH Actions, PHP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2']
+        php: ['8.2', '8.3']
         kubernetes: ['1.27.11', '1.28.7', '1.29.2']
-        laravel: ['9.*', '10.*', '11.*']
+        laravel: ['10.*', '11.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
           - laravel: "10.*"
@@ -31,8 +31,8 @@ jobs:
           - laravel: "11.*"
             testbench: "9.*"
         exclude:
-          - laravel: "11.*"
-            php: "8.1"
+          - laravel: "10.*"
+            php: "8.3"
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2']
-        kubernetes: ['1.24.12', '1.25.8', '1.26.3']
+        kubernetes: ['1.27.11', '1.28.7', '1.29.2']
         laravel: ['9.*', '10.*', '11.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
-          - laravel: "9.*"
-            testbench: "7.*"
           - laravel: "10.*"
             testbench: "8.*"
           - laravel: "11.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,27 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, yaml
           coverage: pcov
 
-      - uses: actions/cache@v3.0.5
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Prepare cache key
+        id: prep
+        run: |
+          PHP_VERSION=${{ matrix.php }}
+          LARAVEL_VERSION=${{ matrix.laravel }}
+          PREFER_VERSION=${{ matrix.prefer }}
+
+          # Remove any .* from the versions
+          LARAVEL_VERSION=${LARAVEL_VERSION//.*}
+
+          echo "cache-key=composer-php-$PHP_VERSION-$LARAVEL_VERSION-$PREFER_VERSION-${{ hashFiles('composer.json') }}" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
         name: Cache dependencies
         with:
-          path: ~/.composer/cache/files
-          key: composer-php-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.prefer }}-${{ hashFiles('composer.json') }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ steps.prep.outputs.cache-key }}
 
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.29.0
+          minikube-version: 1.32.0
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         name: Setup Minikube
         with:
           minikube-version: 1.32.0
+          driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3']
-        kubernetes: ['1.28.9', '1.29.4', '1.30.0']
+        kubernetes: ['1.29.8', '1.30.4', '1.31.0']
         laravel: ['10.*', '11.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
@@ -71,7 +71,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.33.0
+          minikube-version: 1.33.1
           driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3']
-        kubernetes: ['1.27.11', '1.28.7', '1.29.2']
+        kubernetes: ['1.28.9', '1.29.4', '1.30.0']
         laravel: ['10.*', '11.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
@@ -71,7 +71,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.32.0
+          minikube-version: 1.33.0
           driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
           echo "cache-key=composer-php-$PHP_VERSION-$LARAVEL_VERSION-$PREFER_VERSION-${{ hashFiles('composer.json') }}" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache dependencies
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
@@ -101,6 +101,6 @@ jobs:
         run: |
           vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
-      - uses: codecov/codecov-action@v3.1.0
+      - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.27.11 K8s Version](https://img.shields.io/badge/K8s%20v1.27.11-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.28.7 K8s Version](https://img.shields.io/badge/K8s%20v1.28.7-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.29.2 K8s Version](https://img.shields.io/badge/K8s%20v1.29.2-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.28.9 K8s Version](https://img.shields.io/badge/K8s%20v1.28.9-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.29.4 K8s Version](https://img.shields.io/badge/K8s%20v1.29.4-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.30.0 K8s Version](https://img.shields.io/badge/K8s%20v1.30.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
 
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.24.12 K8s Version](https://img.shields.io/badge/K8s%20v1.24.12-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.25.8 K8s Version](https://img.shields.io/badge/K8s%20v1.25.8-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.26.3 K8s Version](https://img.shields.io/badge/K8s%20v1.26.3-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.27.11 K8s Version](https://img.shields.io/badge/K8s%20v1.27.11-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.28.7 K8s Version](https://img.shields.io/badge/K8s%20v1.28.7-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.29.2 K8s Version](https://img.shields.io/badge/K8s%20v1.29.2-Ready-%23326ce5?colorA=306CE8&colorB=green)
+
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.28.9 K8s Version](https://img.shields.io/badge/K8s%20v1.28.9-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.29.4 K8s Version](https://img.shields.io/badge/K8s%20v1.29.4-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.30.0 K8s Version](https://img.shields.io/badge/K8s%20v1.30.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.29.8 K8s Version](https://img.shields.io/badge/K8s%20v1.29.8-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.30.4 K8s Version](https://img.shields.io/badge/K8s%20v1.30.4-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.31.0 K8s Version](https://img.shields.io/badge/K8s%20v1.31.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
 
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^7.23|^8.1|^9.0",
+        "orchestra/testbench": "^8.1|^9.0",
         "phpunit/phpunit": "^9.5.20|^10.0",
         "vimeo/psalm": "^4.20|^5.22"
     },


### PR DESCRIPTION
Multiple versions being tested now out of support as well as a few fixes:

1.  Caching of composer dependencies wasn't working, fixed
2.  Bumped minikube to the current latest
3.  Updated to the most recent 3 kubernetes versions
4.  Fixed an issue observed once where minikube picked the podman engine (and it didn't work for CNI). Explicitly setting docker to avoid that flake in the future.
5. Added PHP 8.3
 
Note: 1.25 & 1.26 also works and passes tests, but it would add more versions and there's a couple spots in the project and docs that say "latest 3", so I left that off the back.