### PR TITLE
use app default event loop for websocket calls

### DIFF
--- a/src/Traits/Cluster/MakesWebsocketCalls.php
+++ b/src/Traits/Cluster/MakesWebsocketCalls.php
@@ -6,7 +6,7 @@ use Closure;
 use Exception;
 use Illuminate\Support\Str;
 use Ratchet\Client\Connector as WebSocketConnector;
-use React\EventLoop\Factory as ReactFactory;
+use React\EventLoop\Loop as ReactLoop;
 use React\Socket\Connector as ReactSocketConnector;
 
 trait MakesWebsocketCalls
@@ -65,7 +65,7 @@ trait MakesWebsocketCalls
             $options['tls']['local_pk'] = $this->sslKey;
         }
 
-        $loop = ReactFactory::create();
+        $loop = ReactLoop::get();
         $socketConnector = new ReactSocketConnector($loop, $options);
         $wsConnector = new WebSocketConnector($loop, $socketConnector);
 


### PR DESCRIPTION
For websocket calls, instead of creating a new event loop, it's better using the default one. This allows other IO events can be attached to the same event loop and act on each other accordingly. For example (pseudo code),
```
// signal a pod by another IO event
$conn = null;

$pod->attach(function (WebSocket $connection) use (&$conn) {
    $conn = $connection;
    ......
});

$loop->addTimer(0.8, function () use (&$conn) {
    if ($conn) $conn->send('0123456789');
});
```

Besides, it is recommended by ReactPHP. The `create` method has been deprecated: https://github.com/reactphp/event-loop/blob/1.x/src/Factory.php#L13-L34