### PR TITLE
Implementing Health Check Methods for Kubernetes Cluste

### DIFF
--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -219,6 +219,27 @@ class KubernetesCluster
     }
 
     /**
+     * Check if the cluster is ready.
+     * 
+     * @return bool
+     */
+    public function isReady()
+    {
+        return $this->runOperation(static::GET_OP, '/readyz') === 'ok';
+    }
+
+    /**
+     * Check if the cluster is live.
+     * 
+     * @return bool
+     */
+    public function isLive()
+    {
+        return $this->runOperation(static::GET_OP, '/livez') === 'ok';
+    }
+
+
+    /**
      * Watch for the current resource or a resource list.
      *
      * @param  string  $path

--- a/src/Traits/RunsClusterOperations.php
+++ b/src/Traits/RunsClusterOperations.php
@@ -587,6 +587,8 @@ trait RunsClusterOperations
         return "{$this->getApiPathPrefix()}/".static::getPlural()."/{$this->getIdentifier()}/attach";
     }
 
+
+
     /**
      * Get the prefix path for the resource.
      *

--- a/tests/HealthCheckTest.php
+++ b/tests/HealthCheckTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use RenokiCo\PhpK8s\KubernetesCluster;
+use RenokiCo\PhpK8s\Test\TestCase;
+
+class HealthCheckTest extends TestCase
+{
+    /**
+     * @group health-check
+     */
+    public function testIsLive()
+    {
+        $this->assertTrue($this->cluster->isLive());
+    }
+
+    /**
+     * @group health-check
+     */
+    public function testIsReady()
+    {
+        $this->assertTrue($this->cluster->isReady());
+    }
+}


### PR DESCRIPTION
Added health check methods isLive and isReady to the KubernetesCluster class. These methods allow us to verify the readiness and liveness of the cluster.