### PR TITLE
[WIP] Update CI workflow to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3']
-        kubernetes: ['1.29.8', '1.30.4', '1.31.0']
-        laravel: ['10.*', '11.*']
+        php: ['8.3', '8.4']
+        kubernetes: ['1.31.10', '1.32.6', '1.33.2']
+        laravel: ['11.*', '12.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
-          - laravel: "10.*"
-            testbench: "8.*"
           - laravel: "11.*"
             testbench: "9.*"
-        exclude:
-          - laravel: "10.*"
-            php: "8.3"
+          - laravel: "12.*"
+            testbench: "10.*"
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}
 
@@ -71,7 +68,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.33.1
+          minikube-version: 1.36.0
           driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2']
+        php: ['8.2', '8.3']
         kubernetes: ['1.27.11', '1.28.7', '1.29.2']
-        laravel: ['9.*', '10.*', '11.*']
+        laravel: ['10.*', '11.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
           - laravel: "10.*"
@@ -31,8 +31,8 @@ jobs:
           - laravel: "11.*"
             testbench: "9.*"
         exclude:
-          - laravel: "11.*"
-            php: "8.1"
+          - laravel: "10.*"
+            php: "8.3"
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2']
-        kubernetes: ['1.24.12', '1.25.8', '1.26.3']
+        kubernetes: ['1.27.11', '1.28.7', '1.29.2']
         laravel: ['9.*', '10.*', '11.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
-          - laravel: "9.*"
-            testbench: "7.*"
           - laravel: "10.*"
             testbench: "8.*"
           - laravel: "11.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,6 @@ jobs:
         run: |
           vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,27 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, yaml
           coverage: pcov
 
-      - uses: actions/cache@v3.0.5
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Prepare cache key
+        id: prep
+        run: |
+          PHP_VERSION=${{ matrix.php }}
+          LARAVEL_VERSION=${{ matrix.laravel }}
+          PREFER_VERSION=${{ matrix.prefer }}
+
+          # Remove any .* from the versions
+          LARAVEL_VERSION=${LARAVEL_VERSION//.*}
+
+          echo "cache-key=composer-php-$PHP_VERSION-$LARAVEL_VERSION-$PREFER_VERSION-${{ hashFiles('composer.json') }}" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
         name: Cache dependencies
         with:
-          path: ~/.composer/cache/files
-          key: composer-php-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.prefer }}-${{ hashFiles('composer.json') }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ steps.prep.outputs.cache-key }}
 
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.29.0
+          minikube-version: 1.32.0
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         name: Setup Minikube
         with:
           minikube-version: 1.32.0
+          driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3']
-        kubernetes: ['1.28.9', '1.29.4', '1.30.0']
+        kubernetes: ['1.29.8', '1.30.4', '1.31.0']
         laravel: ['10.*', '11.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
@@ -71,7 +71,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.33.0
+          minikube-version: 1.33.1
           driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3']
-        kubernetes: ['1.27.11', '1.28.7', '1.29.2']
+        kubernetes: ['1.28.9', '1.29.4', '1.30.0']
         laravel: ['10.*', '11.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
@@ -71,7 +71,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.32.0
+          minikube-version: 1.33.0
           driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
           echo "cache-key=composer-php-$PHP_VERSION-$LARAVEL_VERSION-$PREFER_VERSION-${{ hashFiles('composer.json') }}" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache dependencies
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
@@ -101,6 +101,6 @@ jobs:
         run: |
           vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
-      - uses: codecov/codecov-action@v3.1.0
+      - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.29.8 K8s Version](https://img.shields.io/badge/K8s%20v1.29.8-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.30.4 K8s Version](https://img.shields.io/badge/K8s%20v1.30.4-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.31.0 K8s Version](https://img.shields.io/badge/K8s%20v1.31.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.31.10 K8s Version](https://img.shields.io/badge/K8s%20v1.31.10-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.32.6 K8s Version](https://img.shields.io/badge/K8s%20v1.32.6-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.33.2 K8s Version](https://img.shields.io/badge/K8s%20v1.33.2-Ready-%23326ce5?colorA=306CE8&colorB=green)
 
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.27.11 K8s Version](https://img.shields.io/badge/K8s%20v1.27.11-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.28.7 K8s Version](https://img.shields.io/badge/K8s%20v1.28.7-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.29.2 K8s Version](https://img.shields.io/badge/K8s%20v1.29.2-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.28.9 K8s Version](https://img.shields.io/badge/K8s%20v1.28.9-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.29.4 K8s Version](https://img.shields.io/badge/K8s%20v1.29.4-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.30.0 K8s Version](https://img.shields.io/badge/K8s%20v1.30.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
 
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.24.12 K8s Version](https://img.shields.io/badge/K8s%20v1.24.12-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.25.8 K8s Version](https://img.shields.io/badge/K8s%20v1.25.8-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.26.3 K8s Version](https://img.shields.io/badge/K8s%20v1.26.3-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.27.11 K8s Version](https://img.shields.io/badge/K8s%20v1.27.11-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.28.7 K8s Version](https://img.shields.io/badge/K8s%20v1.28.7-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.29.2 K8s Version](https://img.shields.io/badge/K8s%20v1.29.2-Ready-%23326ce5?colorA=306CE8&colorB=green)
+
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.28.9 K8s Version](https://img.shields.io/badge/K8s%20v1.28.9-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.29.4 K8s Version](https://img.shields.io/badge/K8s%20v1.29.4-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.30.0 K8s Version](https://img.shields.io/badge/K8s%20v1.30.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.29.8 K8s Version](https://img.shields.io/badge/K8s%20v1.29.8-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.30.4 K8s Version](https://img.shields.io/badge/K8s%20v1.30.4-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.31.0 K8s Version](https://img.shields.io/badge/K8s%20v1.31.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
 
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.5|^7.0",
-        "illuminate/macroable": "^9.35|^10.1|^11.0",
-        "illuminate/support": "^9.35|^10.1|^11.0",
+        "guzzlehttp/guzzle": "^7.9",
+        "illuminate/macroable": "^10.1|^11.0",
+        "illuminate/support": "^10.1|^11.0",
         "ratchet/pawl": "^0.4.1",
-        "symfony/process": "^6.0|^7.0",
-        "composer/semver": "^3.0",
+        "symfony/process": "^7.0",
+        "composer/semver": "^3.4",
         "ext-json": "*"
     },
     "suggest": {
@@ -49,10 +49,10 @@
         "test": "vendor/bin/phpunit"
     },
     "require-dev": {
-        "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^8.1|^9.0",
-        "phpunit/phpunit": "^9.5.20|^10.0",
-        "vimeo/psalm": "^4.20|^5.22"
+        "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^9.0",
+        "phpunit/phpunit": "^10.0|^11.0",
+        "vimeo/psalm": "^5.25"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "illuminate/macroable": "^9.35|^10.1|^11.0",
         "illuminate/support": "^9.35|^10.1|^11.0",
         "ratchet/pawl": "^0.4.1",
-        "symfony/process": "^5.4|^6.0|^7.0",
-        "vierbergenlars/php-semver": "^2.1|^3.0"
+        "symfony/process": "^6.0|^7.0",
+        "composer/semver": "^3.0"
     },
     "suggest": {
         "ext-yaml": "YAML extension is used to read or generate YAML from PHP K8s internal classes."

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "orchestra/testbench": "^7.23|^8.1|^9.0",
+        "orchestra/testbench": "^8.1|^9.0",
         "phpunit/phpunit": "^9.5.20|^10.0",
         "vimeo/psalm": "^4.20|^5.22"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "illuminate/support": "^9.35|^10.1|^11.0",
         "ratchet/pawl": "^0.4.1",
         "symfony/process": "^6.0|^7.0",
-        "composer/semver": "^3.0"
+        "composer/semver": "^3.0",
+        "ext-json": "*"
     },
     "suggest": {
         "ext-yaml": "YAML extension is used to read or generate YAML from PHP K8s internal classes."

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^7.9",
-        "illuminate/macroable": "^10.1|^11.0",
-        "illuminate/support": "^10.1|^11.0",
+        "guzzlehttp/guzzle": "^6.5|^7.0",
+        "illuminate/macroable": "^9.35|^10.1|^11.0",
+        "illuminate/support": "^9.35|^10.1|^11.0",
         "ratchet/pawl": "^0.4.1",
-        "symfony/process": "^7.0",
-        "composer/semver": "^3.4",
+        "symfony/process": "^6.0|^7.0",
+        "composer/semver": "^3.0",
         "ext-json": "*"
     },
     "suggest": {
@@ -49,10 +49,10 @@
         "test": "vendor/bin/phpunit"
     },
     "require-dev": {
-        "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^9.0",
-        "phpunit/phpunit": "^10.0|^11.0",
-        "vimeo/psalm": "^5.25"
+        "mockery/mockery": "^1.5",
+        "orchestra/testbench": "^8.1|^9.0",
+        "phpunit/phpunit": "^9.5.20|^10.0",
+        "vimeo/psalm": "^4.20|^5.22"
     },
     "config": {
         "sort-packages": true

--- a/src/Traits/Cluster/ChecksClusterVersion.php
+++ b/src/Traits/Cluster/ChecksClusterVersion.php
@@ -2,29 +2,30 @@
 
 namespace RenokiCo\PhpK8s\Traits\Cluster;
 
+use Composer\Semver\Comparator;
+use Composer\Semver\VersionParser;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
+use JsonException;
 use RenokiCo\PhpK8s\Exceptions\KubernetesAPIException;
-use vierbergenlars\SemVer\version as Semver;
 
 trait ChecksClusterVersion
 {
     /**
      * The Kubernetes cluster version.
-     *
-     * @var \vierbergenlars\SemVer\version|null
      */
-    protected $kubernetesVersion;
+    protected string $kubernetesVersion;
 
     /**
      * Load the cluster version.
      *
      * @return void
      *
-     * @throws \RenokiCo\PhpK8s\Exceptions\KubernetesAPIException
+     * @throws KubernetesAPIException|GuzzleException|JsonException
      */
     protected function loadClusterVersion(): void
     {
-        if ($this->kubernetesVersion) {
+        if (isset($this->kubernetesVersion)) {
             return;
         }
 
@@ -42,9 +43,10 @@ trait ChecksClusterVersion
             );
         }
 
-        $json = @json_decode($response->getBody(), true);
+        $json = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 
-        $this->kubernetesVersion = new Semver($json['gitVersion']);
+        $parser = new VersionParser();
+        $this->kubernetesVersion = $parser->normalize($json['gitVersion']);
     }
 
     /**
@@ -53,12 +55,14 @@ trait ChecksClusterVersion
      *
      * @param  string  $kubernetesVersion
      * @return bool
+     *
+     * @throws KubernetesAPIException|GuzzleException|JsonException
      */
     public function newerThan(string $kubernetesVersion): bool
     {
         $this->loadClusterVersion();
 
-        return Semver::gte(
+        return Comparator::greaterThanOrEqualTo(
             $this->kubernetesVersion, $kubernetesVersion
         );
     }
@@ -69,12 +73,14 @@ trait ChecksClusterVersion
      *
      * @param  string  $kubernetesVersion
      * @return bool
+     *
+     * @throws KubernetesAPIException|GuzzleException|JsonException
      */
     public function olderThan(string $kubernetesVersion): bool
     {
         $this->loadClusterVersion();
 
-        return Semver::lt(
+        return Comparator::lessThan(
             $this->kubernetesVersion, $kubernetesVersion
         );
     }

--- a/tests/ChecksClusterVersionTest.php
+++ b/tests/ChecksClusterVersionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Test;
+
+class ChecksClusterVersionTest extends TestCase
+{
+    public function test_check_cluster_version(): void
+    {
+        $this->assertFalse($this->cluster->olderThan('1.18.0'));
+        $this->assertTrue($this->cluster->newerThan('1.18.0'));
+        $this->assertFalse($this->cluster->newerThan('2.0.0'));
+        $this->assertTrue($this->cluster->olderThan('2.0.0'));
+    }
+}


### PR DESCRIPTION
## Summary
- Update PHP versions to 8.3, 8.4 (latest stable)
- Update Kubernetes versions to 1.31.10, 1.32.6, 1.33.2 (current supported)
- Upgrade Laravel to 11.*, 12.* with corresponding testbench versions
- Update minikube to 1.36.0 (latest stable)
- Upgrade codecov action to v5
- Update README badges to reflect new Kubernetes versions

## Test plan
- [ ] Verify CI workflow runs successfully with new versions
- [ ] Check for any compatibility issues with PHP 8.4
- [ ] Ensure Laravel 12 support works correctly
- [ ] Validate Kubernetes version compatibility
- [ ] Test minikube 1.36.0 functionality

🤖 Generated with [Claude Code](https://claude.ai/code)