### PR TITLE
Add Laravel 13 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,15 @@ jobs:
       matrix:
         php: ["8.2", "8.3", "8.4"]
         kubernetes: ["1.32.9", "1.33.5", "1.34.1"]
-        laravel: ["11.*", "12.*"]
+        laravel: ["11.*", "12.*", "13.*"]
         prefer: [prefer-lowest, prefer-stable]
         include:
           - laravel: "11.*"
             testbench: "9.*"
           - laravel: "12.*"
             testbench: "10.*"
+          - laravel: "13.*"
+            testbench: "11.*"
           # PHP 8.5 only for Laravel 12
           - php: "8.5"
             kubernetes: "1.32.9"
@@ -60,6 +62,37 @@ jobs:
             kubernetes: "1.34.1"
             laravel: "12.*"
             testbench: "10.*"
+            prefer: prefer-stable
+          # PHP 8.5 only for Laravel 13
+          - php: "8.5"
+            kubernetes: "1.32.9"
+            laravel: "13.*"
+            testbench: "11.*"
+            prefer: prefer-lowest
+          - php: "8.5"
+            kubernetes: "1.32.9"
+            laravel: "13.*"
+            testbench: "11.*"
+            prefer: prefer-stable
+          - php: "8.5"
+            kubernetes: "1.33.5"
+            laravel: "13.*"
+            testbench: "11.*"
+            prefer: prefer-lowest
+          - php: "8.5"
+            kubernetes: "1.33.5"
+            laravel: "13.*"
+            testbench: "11.*"
+            prefer: prefer-stable
+          - php: "8.5"
+            kubernetes: "1.34.1"
+            laravel: "13.*"
+            testbench: "11.*"
+            prefer: prefer-lowest
+          - php: "8.5"
+            kubernetes: "1.34.1"
+            laravel: "13.*"
+            testbench: "11.*"
             prefer: prefer-stable
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         kubernetes: ["1.32.9", "1.33.5", "1.34.1"]
         laravel: ["11.*", "12.*", "13.*"]
         prefer: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: "8.2"
+            laravel: "13.*"
         include:
           - laravel: "11.*"
             testbench: "9.*"

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.10",
-        "illuminate/macroable": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0",
+        "illuminate/macroable": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "ratchet/pawl": "^0.4.1",
         "symfony/process": "^7.3.4",
         "composer/semver": "^3.4",
@@ -52,8 +52,8 @@
     "require-dev": {
         "laravel/pint": "dev-main",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^9.0|^10.6.0",
-        "phpunit/phpunit": "^10.0|^11.5",
+        "orchestra/testbench": "^9.0|^10.6.0|^11.0",
+        "phpunit/phpunit": "^10.0|^11.5|^12.0|^13.0",
         "vimeo/psalm": "^6.13.1"
     },
     "config": {


### PR DESCRIPTION
## Summary

- Adds `^13.0` to `illuminate/macroable` and `illuminate/support` version constraints
- Adds `^11.0` to `orchestra/testbench` (testbench 11 targets Laravel 13)
- Adds `^12.0|^13.0` to `phpunit/phpunit` (testbench 11 requires PHPUnit ≥11.5.50)
- Adds `"13.*"` to the CI matrix with the corresponding `testbench: "11.*"` mapping, including PHP 8.5 explicit entries

> Note: `orchestra/testbench` v11 requires PHP ≥8.3, so Laravel 13 test jobs will only run on PHP 8.3+.

## Summary by Sourcery

Add compatibility with Laravel 13 and its testing stack and update CI to cover the new supported versions.

New Features:
- Support Laravel 13 via updated illuminate/macroable and illuminate/support constraints.

Enhancements:
- Expand dev dependency constraints to include orchestra/testbench 11 and PHPUnit 12–13 for newer Laravel support.

CI:
- Extend the GitHub Actions matrix to run tests against Laravel 13 with the appropriate Testbench 11 mapping, including PHP 8.5 job variants.