### PR TITLE
fix: Default PhpK8sException message parameter to empty string

### DIFF
--- a/src/Exceptions/PhpK8sException.php
+++ b/src/Exceptions/PhpK8sException.php
@@ -19,7 +19,7 @@ class PhpK8sException extends Exception
      * @param  string|null  $message
      * @param  int  $code
      */
-    public function __construct($message = null, $code = 0, ?array $payload = null)
+    public function __construct($message = "", $code = 0, ?array $payload = null)
     {
         parent::__construct($message, $code);
 


### PR DESCRIPTION
This avoids an E_DEPRECATED error when calling the `parent::__construct()` method.

Alternatively, line 24 could be changed to `$message ?? ""`

## Summary by Sourcery

Bug Fixes:
- Prevent E_DEPRECATED warnings by ensuring the PhpK8sException constructor always passes a string message to the parent Exception.